### PR TITLE
issue_175: D3 TimelineWidget improvements

### DIFF
--- a/display/html/d3_demo.html
+++ b/display/html/d3_demo.html
@@ -157,7 +157,7 @@
           name: 'Port Relative Wind Speed',
           seconds: 45,
           color: 'red',
-	  //transform: x => 10 * x
+          //transform: x => 10 * x
         },
         MwxStbdRelWindSpeed: {
           name: 'Stbd Relative Wind Speed',
@@ -168,8 +168,12 @@
       widget_list.push(new D3TimelineWidget(
         '#wind_speed_line', rel_wind_line_fields,
         'Knots', {
+          //height: 300,
+          //min: 0,
+          //max: 20,
+          //minRange: 5,
+          //showLegend: false,
           //maxPoints: 30,
-          //height: 300
         }
       ));
       var widget_server = new WidgetServer(widget_list,

--- a/display/js/widgets/d3_widgets.js
+++ b/display/js/widgets/d3_widgets.js
@@ -99,8 +99,8 @@ function TimelineWidget (
 
 function realTimeLineChart (widgetParams) {
   const duration = 1000
-  const { yLabel, colors, fieldNames, fieldInfo, height, min, max, minRange, showLegend }
-    = widgetParams
+  const { yLabel, colors, fieldNames, fieldInfo, height, min, max, minRange, showLegend } =
+    widgetParams
   const margin = { top: 20, right: 10, bottom: 20, left: yLabel ? 50 : 30 }
 
   // Find the maximum seconds specified for any field. If none found, default to 60.
@@ -126,7 +126,6 @@ function realTimeLineChart (widgetParams) {
       const xMax = new Date(new Date(d3.max(data, c => d3.max(c.values, d => d.time)))
         .getTime() - duration)
       const xMin = xMax - maxSeconds * 1000
-
 
       // use bounds if specified, else use max and min of data
       let yMin = min !== null ? min : d3.min(data, c => d3.min(c.values, d => d.value))


### PR DESCRIPTION
I decided to deal with the jitter by having a fixed time interval instead of having it increase as more data comes in. I used the maximum time interval over all the fields, with a somewhat arbitrary default of 60 seconds if no time intervals are specified.
I added min, max and minRange, and also, since you mentioned that people sometimes don't want descriptions in the widget, I added an option for whether to show the legend.