### PR TITLE
added more options for D3 TimelineWidget

### DIFF
--- a/display/html/d3_demo.html
+++ b/display/html/d3_demo.html
@@ -179,6 +179,14 @@
           //max: 20,
           //minRange: 5,
           //showLegend: false,
+          //backgroundColor: 'lightblue',
+          //xTickFontSize: 8,
+          //xTickFormat: '%H:%M:%S',
+          //numXTicks: 5,
+          //yTickFontSize: 8,
+          //yTickFormat: '.2e',
+          //numYTicks: 5,
+          //yUnitsFontSize: 12,
           //maxPoints: 30,
         }
       ));

--- a/display/html/nbp_dashboard_d3.html
+++ b/display/html/nbp_dashboard_d3.html
@@ -452,7 +452,18 @@
   widget_list.push(new D3TimelineWidget('#air_temp_line',
                                         air_temp_line_fields,
                                         'Air Temp C',
-                                        {height:120, showLegend:false}));
+                                        {
+                                          height: 120,
+                                          showLegend: false,
+                                          backgroundColor: 'white',
+                                          xTickFontSize: 8,
+                                          //xTickFormat: '%H:%M:%S',
+                                          //numXTicks: 5,
+                                          yTickFontSize: 8,
+                                          //yTickFormat: '.2e',
+                                          numYTicks: 5,
+                                          yUnitsFontSize: 8
+                                        }));
   /*
   widget_list.push(new TimelineWidget(
     'air_temp_line', air_temp_line_fields, 'Air Temp C',


### PR DESCRIPTION
I added all the options you asked for (plus a few related ones). I also edited one of the TimelineWidgets in nbp_dashboard_d3.html. You can play around with the settings, and then make the same changes in all the TimelineWidgets. However, for the font size and background color settings, it probably makes more sense to do it with CSS, if they're all going to be the same. You might not actually need to set numXTicks, because the reason there were so many ticks before is that I had hardcoded it to make tick marks every 15 seconds - sorry about that!