### PR TITLE
Add ability to truncate log files by hour

### DIFF
--- a/logger/writers/logfile_writer.py
+++ b/logger/writers/logfile_writer.py
@@ -14,20 +14,25 @@ class LogfileWriter(Writer):
   """Write to the specified file. If filename is empty, write to stdout."""
   def __init__(self, filebase=None, flush=True,
                time_format=timestamp.TIME_FORMAT,
-               date_format=timestamp.DATE_FORMAT):
+               date_format=timestamp.DATE_FORMAT,
+               rollover_hourly=False):
     """
     Write timestamped text records to file. Base filename will have
     date appended, in keeping with R2R format recommendations
     (http://www.rvdata.us/operators/directory). When timestamped date on
     records rolls over to next day, create new file with new date suffix.
     ```
-    filebase     Base name of file to write to. Will have record date
-                 appended, e.g.
+    filebase        Base name of file to write to. Will have record date
+                    appended, e.g.
 
-    flush        If True (default), flush after every write() call
+    flush           If True (default), flush after every write() call
 
-    date_fomat   A strftime-compatible string, such as '%Y-%m-%d'; defaults
-                 to whatever's defined in utils.timestamps.DATE_FORMAT.
+    date_fomat      A strftime-compatible string, such as '%Y-%m-%d';
+                    defaults to whatever's defined in
+                    utils.timestamps.DATE_FORMAT.
+
+    rollover_hourly Set files to truncate by hour.  By default files will
+                    truncate by day
     ```
     """
     super().__init__(input_format=Text)
@@ -36,8 +41,10 @@ class LogfileWriter(Writer):
     self.flush = flush
     self.time_format = time_format
     self.date_format = date_format
+    self.rollover_hourly = rollover_hourly
 
     self.current_date = None
+    self.current_hour = None
     self.current_filename = None
     self.writer = None
 
@@ -51,6 +58,7 @@ class LogfileWriter(Writer):
     try:
       time_str = record.split()[0]
       ts = timestamp.timestamp(time_str, time_format=self.time_format)
+      hr_str = self.rollover_hourly and timestamp.date_str(ts, date_format='_%H00') or ""      
       date_str = timestamp.date_str(ts, date_format=self.date_format)
       logging.debug('LogfileWriter date_str: %s', date_str)
     except ValueError:
@@ -58,9 +66,10 @@ class LogfileWriter(Writer):
       return
 
     # Is it time to create a new file to write to?
-    if not self.writer or date_str != self.current_date:
-      self.current_filename = self.filebase + '-' + date_str
+    if not self.writer or date_str != self.current_date or hr_str != self.current_hour:
+      self.current_filename = self.filebase + '-' + date_str + hr_str
       self.current_date = date_str
+      self.current_hour = self.rollover_hourly and hr_str or ""
       logging.info('LogfileWriter opening new file: %s', self.current_filename)
       self.writer = TextFileWriter(self.current_filename, self.flush)
 

--- a/logger/writers/logfile_writer.py
+++ b/logger/writers/logfile_writer.py
@@ -32,6 +32,8 @@ class LogfileWriter(Writer):
                     defaults to whatever's defined in
                     utils.timestamps.DATE_FORMAT.
 
+    suffix          string to apply to the end of the log filename
+
     rollover_hourly Set files to truncate by hour.  By default files will
                     truncate by day
     ```
@@ -42,6 +44,7 @@ class LogfileWriter(Writer):
     self.flush = flush
     self.time_format = time_format
     self.date_format = date_format
+    self.suffix = suffix
     self.rollover_hourly = rollover_hourly
 
     self.current_date = None
@@ -68,7 +71,7 @@ class LogfileWriter(Writer):
 
     # Is it time to create a new file to write to?
     if not self.writer or date_str != self.current_date or hr_str != self.current_hour:
-      self.current_filename = self.filebase + '-' + date_str + hr_str
+      self.current_filename = self.filebase + '-' + date_str + hr_str + self.suffix
       self.current_date = date_str
       self.current_hour = self.rollover_hourly and hr_str or ""
       logging.info('LogfileWriter opening new file: %s', self.current_filename)

--- a/logger/writers/logfile_writer.py
+++ b/logger/writers/logfile_writer.py
@@ -15,6 +15,7 @@ class LogfileWriter(Writer):
   def __init__(self, filebase=None, flush=True,
                time_format=timestamp.TIME_FORMAT,
                date_format=timestamp.DATE_FORMAT,
+               suffix='',
                rollover_hourly=False):
     """
     Write timestamped text records to file. Base filename will have

--- a/test/NBP1406/NBP1406_cruise.yaml
+++ b/test/NBP1406/NBP1406_cruise.yaml
@@ -304,6 +304,7 @@ configs:
     - class: LogfileWriter      # Write to logfile
       kwargs:
         filebase: /var/tmp/log/PCOD/raw/NBP1406_PCOD
+        rollover_hourly: True
     - class: ComposedWriter     # Also prefix with logger name and broadcast
       kwargs:                   # raw NMEA on UDP
         transforms:


### PR DESCRIPTION
Some users may want hourly files instead of daily.  This will be true for larger datasets.  These changes allow users to easily declare if they want hourly files.