### PR TITLE
Require user to specify CORIOLIX API host path

### DIFF
--- a/local/rcrv/README.md
+++ b/local/rcrv/README.md
@@ -6,7 +6,7 @@ RCRV-specific code consists of two primary components:
  1. A project-specific CORIOLIXWriter module in
  ``local/rcrv/modules/coriolix-writer.py``
  
- 1. A script (``build_cruise_definition.py``) that connects to a
+ 2. A script (``build_cruise_definition.py``) that connects to a
  CORIOLIX database to retrieve sensor and parameter definitions and
  reads a local template file (such as the sample at
  ``config_template.yaml``) and creates an OpenRVDAS cruise definition

--- a/local/rcrv/setup.sh
+++ b/local/rcrv/setup.sh
@@ -17,9 +17,14 @@ VENV_BIN=${INSTALL_ROOT}/openrvdas/venv/bin
 
 # HOST_PATH and CRUISE_FILE should be set as appropriate for your
 # installation
-HOST_PATH=http://157.245.173.52:8000/api/
+DEFAULT_HOST_PATH='http://127.0.0.1:8000/api/'
 CRUISE_FILE=${SCRIPT_DIR}/cruise.yaml
 CONFIG_TEMPLATE=${SCRIPT_DIR}/config_template.yaml
+
+echo "#####################################################################"
+read -p "CORIOLIX API HOST_PATH ($DEFAULT_HOST_PATH)? " HOST_PATH
+HOST_PATH=${HOST_PATH:-$DEFAULT_HOST_PATH}
+
 echo
 echo Setting script to read CORIOLIX variables from $HOST_PATH
 echo Setting script to write cruise definitions to $CRUISE_FILE


### PR DESCRIPTION
Requiring the operator to specify the HOST_PATH prevents a hard-coded path from being over-written during git pulls.

Fixed a typo in README.md