### PR TITLE
Allow negative nlat values (i.e. -05733.765)

### DIFF
--- a/logger/utils/record_parser_formats.py
+++ b/logger/utils/record_parser_formats.py
@@ -121,7 +121,7 @@ def nmea_lat_lon(text):
         return None
 
 
-nmea_lat_lon.pattern = r'(\s*(\d+(\.\d*)?|\.\d+)?|)'
+nmea_lat_lon.pattern = r'(\s*[-]?(\d+(\.\d*)?|\.\d+)?|)'
 
 
 def nmea_lat_lon_dir(text):


### PR DESCRIPTION
Ran into an issue parsing a nlat style value that was negative.  This small tweak seems to have resolved the issue.