### PR TITLE
Revert "Issue 338"

### DIFF
--- a/logger/transforms/test_true_winds_transform.py
+++ b/logger/transforms/test_true_winds_transform.py
@@ -177,23 +177,6 @@ SANITY_RESULTS = [
         'PortTrueWindSpeed': 20
     },
 ]
-OFFSET_RESULTS = [
-    {
-        'PortApparentWindDir': 180,
-        'PortTrueWindDir': 0,
-        'PortTrueWindSpeed': 0
-    },
-    {
-        'PortApparentWindDir': 270,
-        'PortTrueWindDir': 225.0,
-        'PortTrueWindSpeed': 14.14213562373095
-    },
-    {
-        'PortApparentWindDir': 180,
-        'PortTrueWindDir': 0,
-        'PortTrueWindSpeed': 0
-    },
-]
 
 
 class TestTrueWindsTransform(unittest.TestCase):
@@ -346,38 +329,6 @@ class TestTrueWindsTransform(unittest.TestCase):
 
         return
 
-
-    ############################
-    def test_offset(self):
-        """Check that the numbers coming out make sense."""
-        check = SANITY_CHECK.copy()
-        expected_results = OFFSET_RESULTS.copy()
-
-        tw = TrueWindsTransform(course_field='CourseTrue',
-                                speed_field='Speed',
-                                heading_field='HeadingTrue',
-                                wind_dir_field='RelWindDir',
-                                wind_speed_field='RelWindSpeed',
-                                true_dir_name='PortTrueWindDir',
-                                true_speed_name='PortTrueWindSpeed',
-                                apparent_dir_name='PortApparentWindDir',
-                                wind_dir_offset=180)
-
-        while check:
-            fields = check.pop(0)
-            record = DASRecord(data_id='truw', fields=fields)
-            result = tw.transform(record)
-            if type(result) is list:
-                if len(result):
-                    result = result[0]
-                else:
-                    result is None
-            expected = expected_results.pop(0)
-            logging.info('sanity result: %s', result)
-            logging.info('sanity expected: %s', expected)
-            self.assertRecursiveAlmostEqual(result.fields, expected)
-
-        return
 
 ################################################################################
 if __name__ == '__main__':

--- a/logger/transforms/true_winds_transform.py
+++ b/logger/transforms/true_winds_transform.py
@@ -43,11 +43,8 @@ class TrueWindsTransform(DerivedDataTransform):
     """
 
     def __init__(self,
-                 course_field,
-                 speed_field,
-                 heading_field,
-                 wind_dir_field,
-                 wind_speed_field,
+                 course_field, speed_field, heading_field,
+                 wind_dir_field, wind_speed_field,
                  true_dir_name,
                  true_speed_name,
                  apparent_dir_name,
@@ -57,7 +54,6 @@ class TrueWindsTransform(DerivedDataTransform):
                  convert_wind_factor=1,
                  convert_speed_factor=1,
                  data_id=None,
-                 wind_dir_offset=0, 
                  metadata_interval=None):
         """
         ```
@@ -98,10 +94,6 @@ class TrueWindsTransform(DerivedDataTransform):
                  output true winds as meters/sec, we'll leave convert_wind_factor
                  as 1 and specify convert_speed_factor=0.5144
 
-        wind_dir_offset
-                 directional offset to be applied to rel wind heading prior to
-                 true wind calculation
-
         metadata_interval - how many seconds between when we attach field metadata
                      to a record we send out.
 
@@ -126,14 +118,6 @@ class TrueWindsTransform(DerivedDataTransform):
 
         self.convert_wind_factor = convert_wind_factor
         self.convert_speed_factor = convert_speed_factor
-
-        try:
-            self.wind_dir_offset = float(wind_dir_offset)
-        except:
-            raise AttributeError('wind_dir_offset must be a numeric value between 0.0 and 360.0')
-
-        if self.wind_dir_offset < 0 or self.wind_dir_offset > 360.0:
-            raise AttributeError('wind_dir_offset must be a numeric value between 0.0 and 360.0')
 
         self.metadata_interval = metadata_interval
         self.last_metadata_send = 0
@@ -282,11 +266,10 @@ class TrueWindsTransform(DerivedDataTransform):
                 continue
 
             logging.debug('Computing new true winds')
-            logging.debug('Corrected apparent wind: %s', (self.wind_dir_val+self.wind_dir_offset) % 360)
             (true_dir, true_speed, apparent_dir) = truew(crse=self.course_val,
                                                          cspd=self.speed_val,
                                                          hd=self.heading_val,
-                                                         wdir=(self.wind_dir_val + self.wind_dir_offset) % 360,
+                                                         wdir=self.wind_dir_val,
                                                          zlr=self.zero_line_reference,
                                                          wspd=self.wind_speed_val)
 


### PR DESCRIPTION
Reverts OceanDataTools/openrvdas#339

Note: "So... my bad for not closely looking at the existing transform. The 'zero_line_reference' is (I'm assuming) how SAMOS defined the installation offset. This pull request can be reverted and deleted."