### PR TITLE
Support raw/binary output with UDPWriter

### DIFF
--- a/logger/writers/test_udp_writer.py
+++ b/logger/writers/test_udp_writer.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import logging
+import signal
+import socket
+import sys
+import threading
+import time
+import unittest
+
+from os.path import dirname, realpath
+sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
+from logger.writers.udp_writer import UDPWriter
+
+SAMPLE_DATA = ['f1 line 1',
+               'f1 line 2',
+               'f1 line 3']
+
+BINARY_DATA = [b'\xff\xa1',
+               b'\xff\xa2',
+               b'\xff\xa3']
+
+
+
+class ReaderTimeout(StopIteration):
+    """A custom exception we can raise when we hit timeout."""
+    pass
+
+################################################################################
+
+
+class TestUDPWriter(unittest.TestCase):
+    ############################
+    def _handler(self, signum, frame):
+        """If timeout fires, raise our custom exception"""
+        logging.info('Read operation timed out')
+        raise ReaderTimeout
+
+    ############################
+    # Actually run the UDPWriter in internal method
+    def write(self, host, port, eol=None, data=None, interval=0, delay=0, encoding='utf-8', mc_interface=None, mc_ttl=3):
+        writer = UDPWriter(destination=host, port=port, eol=eol, encoding=encoding, mc_interface=mc_interface, mc_ttl=mc_ttl)
+
+        time.sleep(delay)
+        for line in data:
+            writer.write(line)
+            time.sleep(interval)
+
+    ############################
+    #
+    # NOTE: The only simple to really verify that it's broadcast, as apposed to
+    #       unicast that we successfully read, is to do packet analysis in
+    #       wireshark/tshark or similar.  But this test case will catch most
+    #       breakage from other developemnt.
+    #
+    def test_broadcast(self):
+        # Main method starts here
+        host = "<broadcast>"
+        port = 8001
+
+        sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, True)
+        sock.bind((host, port))
+
+        # Start the writer
+        threading.Thread(target=self.write,
+                         args=(host, port),
+                         kwargs={"data": SAMPLE_DATA, "interval": 0.1}).start()
+
+        # Set timeout we can catch if things are taking too long
+        signal.signal(signal.SIGALRM, self._handler)
+        signal.alarm(3)
+        try:
+            # Check that we get the lines we expect from it
+            for line in SAMPLE_DATA:
+                record = sock.recv(4096)
+                logging.info('looking for "%s", got "%s"', line, record)
+                if record:
+                    record = record.decode('utf-8')
+                self.assertEqual(line, record)
+        except ReaderTimeout:
+            self.assertTrue(False, 'UDPReader timed out in test - is port '
+                            '%s open?' % addr)
+        signal.alarm(0)
+
+    ############################
+    #
+    # NOTE: We're really testing 2 things here: unicast output and handling odd
+    #       `eol` parameter values (e.g., escaped oddness).
+    #
+    def test_unicast_with_eol(self):
+        # Main method starts here
+        host = ''
+        port = 8002
+        eol = '\\r\\n' # simulate escaped entry from config file
+
+        sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
+        sock.bind((host, port))
+
+        # Start the writer
+        threading.Thread(target=self.write,
+                         args=(host, port),
+                         kwargs={"data": SAMPLE_DATA, "interval": 0.1, "eol": eol}).start()
+
+        # Set timeout we can catch if things are taking too long
+        signal.signal(signal.SIGALRM, self._handler)
+        signal.alarm(3)
+        try:
+            # Check that we get the lines we expect from it
+            for line in SAMPLE_DATA:
+                record = sock.recv(4096)
+                if record:
+                    record = record.decode('utf-8')
+                    line += eol.encode().decode('unicode_escape')
+                    logging.info('looking for "%s", got "%s"', line, record)
+                    self.assertEqual(line, record)
+        except ReaderTimeout:
+            self.assertTrue(False, 'UDPReader timed out in test - is port '
+                            '%s open?' % addr)
+        signal.alarm(0)
+
+    ############################
+    def test_binary(self):
+        # Main method starts here
+        host = ''
+        port = 8003
+
+        sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
+        sock.bind((host, port))
+
+        # Start the writer
+        threading.Thread(target=self.write,
+                         args=(host, port),
+                         kwargs={"data": BINARY_DATA, "interval": 0.1, "encoding": None}).start()
+
+        # Set timeout we can catch if things are taking too long
+        signal.signal(signal.SIGALRM, self._handler)
+        signal.alarm(3)
+        try:
+            # Check that we get the lines we expect from it
+            for line in BINARY_DATA:
+                record = sock.recv(4096)
+                logging.info('looking for "%s", got "%s"', line, record)
+                self.assertEqual(line, record)
+        except ReaderTimeout:
+            self.assertTrue(False, 'UDPReader timed out in test - is port '
+                            '%s open?' % addr)
+        signal.alarm(0)
+
+    ############################
+    #
+    # NOTE: This doesn't actually prove that your network can support multicast
+    #       routing, which is complicated.  It's only verifying that we sent
+    #       packets to a multicast address and received them, all locally.  So,
+    #       it also doesn't really test the IGMP group membership stuff very
+    #       well.  Again, packet analysis is really needed to prove it's
+    #       working.
+    #
+    def test_multicast(self):
+        # Main method starts here
+        host = "239.192.0.100"
+        port = 8004
+        ttl = 3
+        source_ip = socket.gethostbyname(socket.gethostname())
+
+        sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
+
+        # join the multicast group
+        logging.info("joing %s to multicast group %s", source_ip, host)
+        # NOTE: Since these are both already encoded as binary by inet_aton(),
+        #       we can just concatenate them.  Alternatively, could use
+        #       struct.pack("4s4s", ...)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                        socket.inet_aton(host) + socket.inet_aton(source_ip))
+
+        # bind to the mc host, port
+        sock.bind((host, port))
+
+        # Start the writer
+        threading.Thread(target=self.write,
+                         args=(host, port),
+                         kwargs={"data": SAMPLE_DATA, "interval": 0.1, "mc_interface": source_ip, "mc_ttl": ttl}).start()
+
+        # Set timeout we can catch if things are taking too long
+        signal.signal(signal.SIGALRM, self._handler)
+        signal.alarm(3)
+        try:
+            # Check that we get the lines we expect from it
+            for line in SAMPLE_DATA:
+                record = sock.recv(4096)
+                logging.info('looking for "%s", got "%s"', line, record)
+                if record:
+                    record = record.decode('utf-8')
+                self.assertEqual(line, record)
+        except ReaderTimeout:
+            self.assertTrue(False, 'UDPReader timed out in test - is port '
+                            '%s open?' % addr)
+        signal.alarm(0)
+
+
+################################################################################
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbosity', dest='verbosity',
+                        default=0, action='count',
+                        help='Increase output verbosity')
+    args = parser.parse_args()
+
+    LOGGING_FORMAT = '%(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(format=LOGGING_FORMAT)
+
+    LOG_LEVELS = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    args.verbosity = min(args.verbosity, max(LOG_LEVELS))
+    logging.getLogger().setLevel(LOG_LEVELS[args.verbosity])
+
+    unittest.main(warnings='ignore')

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -9,7 +9,6 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 
-from logger.utils.das_record import DASRecord  # noqa: E402
 from logger.writers.network_writer import NetworkWriter  # noqa: E402
 
 
@@ -161,15 +160,7 @@ class UDPWriter(NetworkWriter):
                 self.write(single_record)
             return
 
-        # If record is not a string, try converting to JSON. If we don't know
-        # how, throw a hail Mary and force it into str format
-        if not isinstance(record, str):
-            if type(record) in [int, float, bool, list, dict]:
-                record = json.dumps(record)
-            elif isinstance(record, DASRecord):
-                record = record.as_json()
-            else:
-                record = str(record)
+        # Append eol if configured
         if self.eol:
             record += self.eol
 

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -131,7 +131,8 @@ class UDPWriter(Writer):
             destination = '<broadcast>'
 
         self.destination = destination
-        self.port = port
+        # make sure port gets stored as an int, even if passed in as a string
+        self.port = int(port)
 
         # Try opening the socket
         self.socket = self._open_socket()

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -9,10 +9,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 
-from logger.writers.network_writer import NetworkWriter  # noqa: E402
+from logger.utils.formats import Text
+from logger.writers.writer import Writer
 
 
-class UDPWriter(NetworkWriter):
+class UDPWriter(Writer):
     """Write UDP packets to network."""
 
     def __init__(self, port, destination='',
@@ -50,6 +51,8 @@ class UDPWriter(NetworkWriter):
                      before sending.
         ```
         """
+        super().__init__(input_format=Text)
+
         self.ttl = ttl
         self.num_retry = num_retry
         self.warning_limit = warning_limit

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -18,9 +18,9 @@ class UDPWriter(Writer):
 
     def __init__(self, port, destination='',
                  interface='',  # DEPRECATED!
-                 ttl=3, num_retry=2, warning_limit=5, eol=''):
-        """
-        Write text records to a network socket.
+                 ttl=3, num_retry=2, warning_limit=5, eol='',
+                 encoding='utf-8', encoding_errors='ignore'):
+        """Write text records to a network socket.
         ```
         port         Port to which packets should be sent
 
@@ -49,9 +49,21 @@ class UDPWriter(Writer):
 
         eol          If specified, an end of line string to append to record
                      before sending.
+
+        encoding - 'utf-8' by default. If empty or None, do not attempt any
+                decoding and return raw bytes. Other possible encodings are
+                listed in online documentation here:
+                https://docs.python.org/3/library/codecs.html#standard-encodings
+
+        encoding_errors - 'ignore' by default. Other error strategies are
+                'strict', 'replace', and 'backslashreplace', described here:
+                https://docs.python.org/3/howto/unicode.html#encodings
         ```
+
         """
-        super().__init__(input_format=Text)
+        super().__init__(input_format=Text,
+                         encoding=encoding,
+                         encoding_errors=encoding_errors)
 
         self.ttl = ttl
         self.num_retry = num_retry
@@ -180,7 +192,7 @@ class UDPWriter(Writer):
         rec_len = len(record)
         while num_tries <= self.num_retry and bytes_sent < rec_len:
             try:
-                bytes_sent = self.socket.send(record.encode('utf-8'))
+                bytes_sent = self.socket.send(self._encode_str(record))
 
                 # If here, write at least partially succeeded. Reset warnings
                 #

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -69,8 +69,13 @@ class UDPWriter(Writer):
         self.num_retry = num_retry
         self.warning_limit = warning_limit
         self.num_warnings = 0
-        self.eol = eol
         self.good_writes = 0 # consecutive good writes, for detecting UDP errors
+
+        # 'eol' comes in as a (probably escaped) string. We need to
+        # unescape it, which means converting to bytes and back.
+        if eol is not None and self.encoding:
+            eol = self._unescape_str(eol)
+        self.eol = eol
 
         self.target_str = 'interface: %s, destination: %s, port: %d' % (
             interface, destination, port)

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -176,7 +176,7 @@ class UDPWriter(NetworkWriter):
 
         num_tries = bytes_sent = 0
         rec_len = len(record)
-        while num_tries < self.num_retry and bytes_sent < rec_len:
+        while num_tries <= self.num_retry and bytes_sent < rec_len:
             try:
                 bytes_sent = self.socket.send(record.encode('utf-8'))
 


### PR DESCRIPTION
Ahoy!  I ran into a couple issues this last cruise aboard the E/V Nautilus and decided to get my hands dirty and fix them.  My primary issue was that we couldn't read raw binary data with a `NetworkReader` and then send it unmodified to a couple different systems using `UDPWriter` instances.  `NetworkReader` handles raw/binary data fine by setting `encoding=None`, but `UDPWriter` was blindly encoding it into UTF-8, which obviously garbles it all up.

I tried to keep this branch focused on just this issue, but couldn't help but fix a couple other problems I bumped into along the way.  I actually have a whole 2nd branch full of `SerialWriter`, `NetworkWriter`, and testsuite fixes to send along after this, but figured I'd start small(ish).  We're planning on using OpenRVDAS more and more on the Nautilus, so I'm going to keep on find-and-fixing while I'm out here.  

All the tests that passed before still pass (there are some `SerialWriter` errors already present that I've got fixed in my next branch).