### PR TITLE
Replace NetworkWriter with TCPWriter

### DIFF
--- a/logger/listener/listen.py
+++ b/logger/listener/listen.py
@@ -293,7 +293,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--udp', dest='udp', default=None,
                         help='Comma-separated udp addresses to read from, '
-                        'where an address is of format [source]:port and '
+                        'where an address is of format [source:]port[,...] and '
                         'source, when provided, is either the address of the '
                         'interface you want to listen on, or a multicast '
                         'group.')
@@ -484,15 +484,18 @@ if __name__ == '__main__':
                         'Will be appended to filename, with one file per date.')
 
     parser.add_argument('--write_network', dest='write_network', default=None,
-                        help='Network address(es) to write to')
+                        help='Network address(es) to write to.  NOTE: This has '
+                        'been REPLACED by --write_udp and --write_tcp.')
 
     parser.add_argument('--write_tcp', dest='write_tcp', default=None,
                         help='TCP destination host/IP(s) and port(s) to write '
-                        'to. Format destination:port[,...]')
+                        'to. Format destination:port[,...].  NOTE: This replaces '
+                        'the old --write_network argument.')
 
     parser.add_argument('--write_udp', dest='write_udp', default=None,
                         help='UDP interface(s) and port(s) to write to. Format '
-                        '[destination]:port[,...]')
+                        '[destination:]port[,...].  NOTE: This replaces the old '
+                        '--write_network argument.')
 
     parser.add_argument('--write_serial', dest='write_serial', default=None,
                         help='Comma-separated serial port spec containing at '
@@ -682,9 +685,11 @@ if __name__ == '__main__':
                     addr = addr_str.split(':')
                     if len(addr) > 2:
                         parser.error('Format error for --udp argument. Format '
-                                     'should be [source]:port[,...]')
+                                     'should be [source:]port[,...]')
+                    if len(addr) < 2:
+                        addr.insert(0, '')
                     source = addr[0]
-                    port = addr[1]
+                    port = int(addr[1])
                     readers.append(UDPReader(port=port, source=source, eol=eol, encoding=encoding))
 
             if new_args.redis:
@@ -817,7 +822,9 @@ if __name__ == '__main__':
                     addr = addr_str.split(':')
                     if len(addr) > 2:
                         parser.error('Format err for --write_tcp argument. Format '
-                                     'should be [destination]:port[,...]')
+                                     'should be [destination:]port[,...]')
+                    if len(addr) < 2:
+                        addr.insert(0, '')
                     dest = addr[0]
                     port = int(addr[1])
                     writers.append(TCPWriter(port=port, destination=dest,
@@ -830,7 +837,9 @@ if __name__ == '__main__':
                     addr = addr_str.split(':')
                     if len(addr) > 2:
                         parser.error('Format error for --write_udp argument. Format '
-                                     'should be [destination]:port[,...]')
+                                     'should be [destination:]port[,...]')
+                    if len(addr) < 2:
+                        addr.insert(0, '')
                     dest = addr[0]
                     port = int(addr[1])
                     writers.append(UDPWriter(port=port, destination=dest,

--- a/logger/listener/listen.py
+++ b/logger/listener/listen.py
@@ -76,6 +76,7 @@ from logger.transforms.true_winds_transform import TrueWindsTransform  # noqa: E
 
 # Compute and emit various NMEA strings
 from logger.writers.network_writer import NetworkWriter  # noqa: E402
+from logger.writers.tcp_writer import TCPWriter
 from logger.writers.udp_writer import UDPWriter  # noqa: E402
 from logger.writers.serial_writer import SerialWriter  # noqa: E402
 from logger.writers.redis_writer import RedisWriter  # noqa: E402
@@ -485,6 +486,10 @@ if __name__ == '__main__':
     parser.add_argument('--write_network', dest='write_network', default=None,
                         help='Network address(es) to write to')
 
+    parser.add_argument('--write_tcp', dest='write_tcp', default=None,
+                        help='TCP destination host/IP(s) and port(s) to write '
+                        'to. Format destination:port[,...]')
+
     parser.add_argument('--write_udp', dest='write_udp', default=None,
                         help='UDP interface(s) and port(s) to write to. Format '
                         '[destination]:port[,...]')
@@ -797,6 +802,18 @@ if __name__ == '__main__':
                 eol = all_args.network_eol
                 for addr in new_args.write_network.split(','):
                     writers.append(NetworkWriter(network=addr, eol=eol))
+
+            if new_args.write_tcp:
+                eol = all_args.network_eol
+                for addr_str in new_args.write_tcp.split(','):
+                    addr = addr_str.split(':')
+                    if len(addr) > 2:
+                        parser.error('Format err for --write_tcp argument. Format '
+                                     'should be [destination]:port[,...]')
+                    dest = addr[0]
+                    port = int(addr[1])
+                    writers.append(TCPWriter(port=port, destination=dest,
+                                             eol=eol))
 
             if new_args.write_udp:
                 eol = all_args.network_eol

--- a/logger/listener/listen.py
+++ b/logger/listener/listen.py
@@ -292,8 +292,10 @@ if __name__ == '__main__':
 
     parser.add_argument('--udp', dest='udp', default=None,
                         help='Comma-separated udp addresses to read from, '
-                        'where an address is of format [source:]port and '
-                        'source, when provided, is a multicast group.')
+                        'where an address is of format [source]:port and '
+                        'source, when provided, is either the address of the '
+                        'interface you want to listen on, or a multicast '
+                        'group.')
 
     parser.add_argument('--database', dest='database', default=None,
                         help='Format: user@host:database:field1,field2,... '
@@ -485,7 +487,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--write_udp', dest='write_udp', default=None,
                         help='UDP interface(s) and port(s) to write to. Format '
-                        '[[interface:]destination:]port')
+                        '[destination]:port[,...]')
 
     parser.add_argument('--write_serial', dest='write_serial', default=None,
                         help='Comma-separated serial port spec containing at '
@@ -668,13 +670,11 @@ if __name__ == '__main__':
                 eol = all_args.network_eol
                 for addr_str in new_args.udp.split(','):
                     addr = addr_str.split(':')
-                    source = ''
-                    port = int(addr[-1])  # port is last arg
-                    if len(addr) > 1:
-                        source = addr[-2]  # source (multi/broadcast) is prev arg
                     if len(addr) > 2:
                         parser.error('Format error for --udp argument. Format '
-                                     'should be [source:]port')
+                                     'should be [source]:port[,...]')
+                    source = addr[0]
+                    port = addr[1]
                     readers.append(UDPReader(port=port, source=source, eol=eol))
 
             if new_args.redis:
@@ -802,18 +802,13 @@ if __name__ == '__main__':
                 eol = all_args.network_eol
                 for addr_str in new_args.write_udp.split(','):
                     addr = addr_str.split(':')
-                    dest = ''
-                    interface = ''
-                    port = int(addr[-1])  # port is last arg
-                    if len(addr) > 1:
-                        dest = addr[-2]  # destination (multi/broadcast) is prev arg
                     if len(addr) > 2:
-                        interface = addr[-3]  # interface is first arg
-                    if len(addr) > 3:
                         parser.error('Format error for --write_udp argument. Format '
-                                     'should be [[interface:]destination:]port')
+                                     'should be [destination]:port[,...]')
+                    dest = addr[0]
+                    port = int(addr[1])
                     writers.append(UDPWriter(port=port, destination=dest,
-                                             interface=interface, eol=eol))
+                                             eol=eol))
 
             # SerialWriter is a little more complicated than other readers
             # because it can take so many parameters. Use the kwargs trick to

--- a/logger/listener/listen.py
+++ b/logger/listener/listen.py
@@ -501,8 +501,11 @@ if __name__ == '__main__':
                         'parameters.')
 
     parser.add_argument('--network_eol', dest='network_eol', default=None,
-                        help='Optional EOL string to add to write_network '
-                        'and write_udp transmissions.')
+                        help='Optional EOL string to add to writen records.')
+
+    parser.add_argument('--encoding', dest='encoding', default='utf-8',
+                        help="Optional encoding of records.  Default is utf-8, "
+                        "specify '' for raw/binary.")
 
     parser.add_argument('--write_redis', dest='write_redis', default=None,
                         help='Redis pubsub channel[@host[:port]] to write to. '
@@ -668,11 +671,13 @@ if __name__ == '__main__':
                         refresh_file_spec=all_args.refresh_file_spec))
 
             if new_args.network:
+                encoding = all_args.encoding
                 for addr in new_args.network.split(','):
-                    readers.append(NetworkReader(network=addr))
+                    readers.append(NetworkReader(network=addr, encoding=encoding))
 
             if new_args.udp:
                 eol = all_args.network_eol
+                encoding = all_args.encoding
                 for addr_str in new_args.udp.split(','):
                     addr = addr_str.split(':')
                     if len(addr) > 2:
@@ -680,7 +685,7 @@ if __name__ == '__main__':
                                      'should be [source]:port[,...]')
                     source = addr[0]
                     port = addr[1]
-                    readers.append(UDPReader(port=port, source=source, eol=eol))
+                    readers.append(UDPReader(port=port, source=source, eol=eol, encoding=encoding))
 
             if new_args.redis:
                 for channel in new_args.redis.split(','):
@@ -790,21 +795,24 @@ if __name__ == '__main__':
             ##########################
             # Writers
             if new_args.write_file:
+                encoding = all_args.encoding
                 for filename in new_args.write_file.split(','):
                     if filename == '-':
                         filename = None
-                    writers.append(FileWriter(filename=filename))
+                    writers.append(FileWriter(filename=filename, encoding=encoding))
 
             if new_args.write_logfile:
                 writers.append(LogfileWriter(filebase=new_args.write_logfile))
 
             if new_args.write_network:
                 eol = all_args.network_eol
+                encoding = all_args.encoding
                 for addr in new_args.write_network.split(','):
-                    writers.append(NetworkWriter(network=addr, eol=eol))
+                    writers.append(NetworkWriter(network=addr, eol=eol, encoding=encoding))
 
             if new_args.write_tcp:
                 eol = all_args.network_eol
+                encoding = all_args.encoding
                 for addr_str in new_args.write_tcp.split(','):
                     addr = addr_str.split(':')
                     if len(addr) > 2:
@@ -813,10 +821,11 @@ if __name__ == '__main__':
                     dest = addr[0]
                     port = int(addr[1])
                     writers.append(TCPWriter(port=port, destination=dest,
-                                             eol=eol))
+                                             eol=eol, encoding=encoding))
 
             if new_args.write_udp:
                 eol = all_args.network_eol
+                encoding = all_args.encoding
                 for addr_str in new_args.write_udp.split(','):
                     addr = addr_str.split(':')
                     if len(addr) > 2:
@@ -825,7 +834,7 @@ if __name__ == '__main__':
                     dest = addr[0]
                     port = int(addr[1])
                     writers.append(UDPWriter(port=port, destination=dest,
-                                             eol=eol))
+                                             eol=eol, encoding=encoding))
 
             # SerialWriter is a little more complicated than other readers
             # because it can take so many parameters. Use the kwargs trick to

--- a/logger/writers/network_writer.py
+++ b/logger/writers/network_writer.py
@@ -51,11 +51,16 @@ class NetworkWriter(Writer):
                              ' or \':port\' format. Found "%s"' % network)
         self.network = network
         self.num_retry = num_retry
-        self.eol = eol
 
         # split network into host, port
         (self.host, self.port) = self.network.split(':')
         self.port = int(self.port)
+
+        # 'eol' comes in as a (probably escaped) string. We need to
+        # unescape it, which means converting to bytes and back.
+        if eol is not None and self.encoding:
+            eol = self._unescape_str(eol)
+        self.eol = eol
 
         # do name resolution once in the constructor
         #

--- a/logger/writers/network_writer.py
+++ b/logger/writers/network_writer.py
@@ -17,7 +17,7 @@ class NetworkWriter(Writer):
     def __init__(self, network, num_retry=2, eol='',
                  encoding='utf-8', encoding_errors='ignore'):
         """
-        Write text records to a network socket.
+        Write records to a TCP network socket.
 
         NOTE: tcp is nominally implemented, but DOES NOT WORK!
         ```
@@ -85,25 +85,9 @@ class NetworkWriter(Writer):
     def _open_socket(self):
         """Try to open and return the network socket.
         """
-        # TCP if host is specified
-        if self.host:
-            this_socket = socket.socket(family=socket.AF_INET,
-                                        type=socket.SOCK_STREAM,
-                                        proto=socket.IPPROTO_TCP)
-
-        # UDP broadcast if no host specified. Note that there's some
-        # dodginess I don't understand about networks: if '<broadcast>' is
-        # specified, socket tries to send on *all* interfaces. if '' is
-        # specified, it tries to send on *any* interface.
-        else:
-            this_socket = socket.socket(family=socket.AF_INET,
-                                        type=socket.SOCK_DGRAM,
-                                        proto=socket.IPPROTO_UDP)
-            this_socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, True)
-            try:  # Raspbian doesn't recognize SO_REUSEPORT
-                this_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, True)
-            except AttributeError:
-                logging.warning('Unable to set socket REUSEPORT; system may not support it.')
+        this_socket = socket.socket(family=socket.AF_INET,
+                                    type=socket.SOCK_STREAM,
+                                    proto=socket.IPPROTO_TCP)
 
         # Try connecting
         try:

--- a/logger/writers/network_writer.py
+++ b/logger/writers/network_writer.py
@@ -8,7 +8,6 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils.formats import Text  # noqa: E402
-from logger.utils.das_record import DASRecord  # noqa: E402
 from logger.writers.writer import Writer  # noqa: E402
 
 
@@ -110,15 +109,7 @@ class NetworkWriter(Writer):
                 self.write(single_record)
             return
 
-        # If record is not a string, try converting to JSON. If we don't know
-        # how, throw a hail Mary and force it into str format
-        if not isinstance(record, str):
-            if type(record) in [int, float, bool, list, dict]:
-                record = json.dumps(record)
-            elif isinstance(record, DASRecord):
-                record = record.as_json()
-            else:
-                record = str(record)
+        # Append eol if configured
         if self.eol:
             record += self.eol
 

--- a/logger/writers/network_writer.py
+++ b/logger/writers/network_writer.py
@@ -7,141 +7,15 @@ import sys
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
-from logger.utils.formats import Text  # noqa: E402
 from logger.writers.writer import Writer  # noqa: E402
 
 
 class NetworkWriter(Writer):
-    """Write TCP packtes to network."""
-
-    def __init__(self, port, destination,
-                 num_retry=2, warning_limit=5, eol='',
+    def __init__(self, network, num_retry=2, eol='',
                  encoding='utf-8', encoding_errors='ignore'):
-        """
-        Write records to a TCP network socket.
-
-        ```
-        port         Port to which packets should be sent
-
-        destination  The destination to send TCP packets to.  Can be resolvable hostname
-                     or valid IP address.
-
-        num_retry    Number of times to retry if write fails.
-
-        warning_limit  Number of times the writer gives up on writing a message
-                     (without any intervening successes) before it gives up complaining
-                     about failures.
-
-        eol          If specified, an end of line string to append to record
-                     before sending
-
-        encoding - 'utf-8' by default. If empty or None, do not attempt any
-                decoding and return raw bytes. Other possible encodings are
-                listed in online documentation here:
-                https://docs.python.org/3/library/codecs.html#standard-encodings
-
-        encoding_errors - 'ignore' by default. Other error strategies are
-                'strict', 'replace', and 'backslashreplace', described here:
-                https://docs.python.org/3/howto/unicode.html#encodings
-
-        ```
-        """
-
         super().__init__(encoding=encoding,
                          encoding_errors=encoding_errors)
+        logging.error("NetworkWriter has been replaced by TCPWriter and UDPWriter")
 
-        self.num_retry = num_retry
-        self.warning_limit = warning_limit
-        self.num_warnings = 0
-
-        # 'eol' comes in as a (probably escaped) string. We need to
-        # unescape it, which means converting to bytes and back.
-        if eol is not None and self.encoding:
-            eol = self._unescape_str(eol)
-        self.eol = eol
-
-        # do name resolution once in the constructor
-        #
-        # NOTE: This means the hostname must be valid when we start, otherwise
-        #       the config_check code will puke.  That's fine.  The alternative
-        #       is we let name resolution happen while we're running, but then
-        #       each failed lookup is going to block our write() routine for a
-        #       few seconds - not good.
-        #
-        # NOTE: This also catches specifying impropperly formatted IP
-        #       addresses.  The only way through gethostbyname() w/out throwing
-        #       an exception is to provide a valid hostname or IP address.
-        #       Propperly formatted IPs just get returned.
-        #
-        self.destination = socket.gethostbyname(destination)
-
-        # make sure port gets stored as an int, even if passed in as a string
-        self.port = int(port)
-
-        # Try opening the socket
-        self.socket = self._open_socket()
-
-    ############################
-    def _open_socket(self):
-        """Try to open and return the network socket.
-        """
-        this_socket = socket.socket(family=socket.AF_INET,
-                                    type=socket.SOCK_STREAM,
-                                    proto=socket.IPPROTO_TCP)
-
-        # Try connecting
-        try:
-            this_socket.connect((self.destination, self.port))
-            return this_socket
-        except OSError as e:
-            logging.warning('Unable to connect to %s: %s', self.network, e)
-            return None
-
-    ############################
     def write(self, record):
-        """Write the record to the network."""
-        # If we don't have a record, there's nothing to do
-        if not record:
-            return
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling write() on each of the list elements in order.
-        if isinstance(record, list):
-            for single_record in record:
-                self.write(single_record)
-            return
-
-        # Append eol if configured
-        if self.eol:
-            record += self.eol
-
-        # If socket isn't connected, try reconnecting. If we can't
-        # reconnect, complain and return without writing.
-        if not self.socket:
-            self.socket = self._open_socket()
-        if not self.socket:
-            logging.error('Unable to write record to %s:%d',
-                          self.destination, self.port)
-            return
-
-        num_tries = bytes_sent = 0
-        rec_len = len(record)
-        while num_tries <= self.num_retry and bytes_sent < rec_len:
-            try:
-                bytes_sent = self.socket.send(self._encode_str(record))
-                if self.num_warnings == self.warning_limit:
-                    logging.info('NetworkWriter.write() succeeded in writing after series of'
-                                 'failures; resetting warnings.')
-                    self.num_warnings = 0 # we've succeeded
-
-            except OSError as e:
-                if self.num_warnings < self.warning_limit:
-                    logging.error('NetworkWriter error: %s:%d: %s', self.destination, self.port, str(e))
-                    logging.error('NetworkWriter record: %s', record)
-                    self.num_warnings += 1
-                    if self.num_warnings == self.warning_limit:
-                        logging.error('NetworkWriter.write() - muting errors')
-            num_tries += 1
-
-        logging.debug('NetworkWriter.write() wrote %d/%d bytes after %d tries',
-                      bytes_sent, rec_len, num_tries)
+        logging.error("not writing anything: NetworkWriter has been replaced by TCPWriter and UDPWriter")

--- a/logger/writers/network_writer.py
+++ b/logger/writers/network_writer.py
@@ -124,7 +124,7 @@ class NetworkWriter(Writer):
 
         num_tries = bytes_sent = 0
         rec_len = len(record)
-        while num_tries < self.num_retry and bytes_sent < rec_len:
+        while num_tries <= self.num_retry and bytes_sent < rec_len:
             try:
                 bytes_sent = self.socket.send(record.encode('utf-8'))
             except OSError as e:

--- a/logger/writers/tcp_writer.py
+++ b/logger/writers/tcp_writer.py
@@ -80,7 +80,7 @@ class TCPWriter(Writer):
         # make sure port gets stored as an int, even if passed in as a string
         self.port = int(port)
 
-        # socket get's initialized on-demand in write()
+        # socket gets initialized on-demand in write()
         #
         # NOTE: Since connect() can actually fail w/ a TCP socket, we don't try
         #       that here.  Let's just do safe things.

--- a/logger/writers/tcp_writer.py
+++ b/logger/writers/tcp_writer.py
@@ -80,8 +80,12 @@ class TCPWriter(Writer):
         # make sure port gets stored as an int, even if passed in as a string
         self.port = int(port)
 
-        # Try opening the socket
-        self.socket = self._open_socket()
+        # socket get's initialized on-demand in write()
+        #
+        # NOTE: Since connect() can actually fail w/ a TCP socket, we don't try
+        #       that here.  Let's just do safe things.
+        #
+        self.socket = None
 
     ############################
     def _open_socket(self):
@@ -90,18 +94,29 @@ class TCPWriter(Writer):
         this_socket = socket.socket(family=socket.AF_INET,
                                     type=socket.SOCK_STREAM,
                                     proto=socket.IPPROTO_TCP)
-
-        # FIXME: double-check i don't need to do anything else in here...
-        #        recv-side needs to do a lot (bind, accept), but i think
-        #        send-side just needs to connect
+        this_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        try:  # Raspbian doesn't recognize SO_REUSEPORT
+            this_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, True)
+        except AttributeError:
+            logging.warning('Unable to set socket REUSEPORT; may be unsupported')
 
         # Try connecting
         try:
             this_socket.connect((self.destination, self.port))
-            return this_socket
         except OSError as e:
-            logging.warning('Unable to connect to %s: %s', self.network, e)
+            if self.num_warnings < self.warning_limit:
+                logging.error('Unable to connect to %s:%d: %s', self.destination, self.port, e)
+                self.num_warnings += 1
+                if self.num_warnings == self.warning_limit:
+                    logging.error('TCPWriter._open_socket() - muting errors')
             return None
+
+        # success, reset warning counter
+        if self.num_warnings == self.warning_limit:
+            logging.info('TCPWriter._open_socket() successfully connected after a series of '
+                         'failures; restting warnings.')
+        self.num_warnings = 0
+        return this_socket
 
     ############################
     def write(self, record):
@@ -121,33 +136,45 @@ class TCPWriter(Writer):
         if self.eol:
             record += self.eol
 
-        # If socket isn't connected, try reconnecting. If we can't
-        # reconnect, complain and return without writing.
-        if not self.socket:
-            self.socket = self._open_socket()
-        if not self.socket:
-            logging.error('Unable to write record to %s:%d',
-                          self.destination, self.port)
-            return
-
-        num_tries = bytes_sent = 0
+        # NOTE: Unlike UDP socket, which really only can detect failure during
+        #       send() (and even then only very poorly), a TCP connect() can
+        #       fail, so we need to track attempts to connect in order to honor
+        #       `num_retry` on a disconnected socket.
+        #
+        #       We also need to tear down and start over with a fresh connect()
+        #       if send() fails.
+        #
+        num_tries = 0
+        bytes_sent = 0
         rec_len = len(record)
         while num_tries <= self.num_retry and bytes_sent < rec_len:
+            num_tries += 1
+            # attempt to connect socket if needed, up to `num_tries` times
+            if not self.socket:
+                self.socket = self._open_socket()
+            if not self.socket:
+                # no need for further error messages, _open_socket() will have
+                # already complained sufficiently
+                continue
+
+            # we're connected, try sending
             try:
                 bytes_sent = self.socket.send(self._encode_str(record))
-                if self.num_warnings == self.warning_limit:
-                    logging.info('TCPWriter.write() succeeded in writing after series of'
-                                 'failures; resetting warnings.')
-                    self.num_warnings = 0 # we've succeeded
-
             except OSError as e:
-                if self.num_warnings < self.warning_limit:
-                    logging.error('TCPWriter error: %s:%d: %s', self.destination, self.port, str(e))
-                    logging.error('TCPWriter record: %s', record)
-                    self.num_warnings += 1
-                    if self.num_warnings == self.warning_limit:
-                        logging.error('TCPWriter.write() - muting errors')
-            num_tries += 1
+                # send failed, we need to disconnect and start over
+                #
+                # NOTE: In order to get this far, we have to have successfully
+                #       connected, which means we JUST reset self.num_warnings
+                #
+                logging.error('TCPWriter: send() error: %s:%d: %s', self.destination, self.port, str(e))
+                self.num_warnings += 1
+                self.socket = None
+                continue
+
+            # check to see if we really wrote it all
+            if bytes_sent < rec_len:
+                logging.warning('TCPWriter: send() did not send the whole record: '
+                                'bytes_sent=%d, rec_len=%d', bytes_sent, rec_len)
 
         logging.debug('TCPWriter.write() wrote %d/%d bytes after %d tries',
                       bytes_sent, rec_len, num_tries)

--- a/logger/writers/tcp_writer.py
+++ b/logger/writers/tcp_writer.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import socket
+import sys
+
+from os.path import dirname, realpath
+sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
+from logger.writers.writer import Writer  # noqa: E402
+
+
+# FIXME: implement tcp, remove udp entirely, maybe rename TCPWriter?  could
+#        make an issue for this.
+#
+class TCPWriter(Writer):
+    """Write TCP packtes to network."""
+
+    def __init__(self, port, destination,
+                 num_retry=2, warning_limit=5, eol='',
+                 encoding='utf-8', encoding_errors='ignore'):
+        """
+        Write records to a TCP network socket.
+
+        ```
+        port         Port to which packets should be sent
+
+        destination  The destination to send TCP packets to.  Can be resolvable hostname
+                     or valid IP address.
+
+        num_retry    Number of times to retry if write fails.
+
+        warning_limit  Number of times the writer gives up on writing a message
+                     (without any intervening successes) before it gives up complaining
+                     about failures.
+
+        eol          If specified, an end of line string to append to record
+                     before sending
+
+        encoding - 'utf-8' by default. If empty or None, do not attempt any
+                decoding and return raw bytes. Other possible encodings are
+                listed in online documentation here:
+                https://docs.python.org/3/library/codecs.html#standard-encodings
+
+        encoding_errors - 'ignore' by default. Other error strategies are
+                'strict', 'replace', and 'backslashreplace', described here:
+                https://docs.python.org/3/howto/unicode.html#encodings
+
+        ```
+        """
+
+        super().__init__(encoding=encoding,
+                         encoding_errors=encoding_errors)
+
+        self.num_retry = num_retry
+        self.warning_limit = warning_limit
+        self.num_warnings = 0
+
+        # 'eol' comes in as a (probably escaped) string. We need to
+        # unescape it, which means converting to bytes and back.
+        if eol is not None and self.encoding:
+            eol = self._unescape_str(eol)
+        self.eol = eol
+
+        # do name resolution once in the constructor
+        #
+        # NOTE: This means the hostname must be valid when we start, otherwise
+        #       the config_check code will puke.  That's fine.  The alternative
+        #       is we let name resolution happen while we're running, but then
+        #       each failed lookup is going to block our write() routine for a
+        #       few seconds - not good.
+        #
+        # NOTE: This also catches specifying impropperly formatted IP
+        #       addresses.  The only way through gethostbyname() w/out throwing
+        #       an exception is to provide a valid hostname or IP address.
+        #       Propperly formatted IPs just get returned.
+        #
+        self.destination = socket.gethostbyname(destination)
+
+        # make sure port gets stored as an int, even if passed in as a string
+        self.port = int(port)
+
+        # Try opening the socket
+        self.socket = self._open_socket()
+
+    ############################
+    def _open_socket(self):
+        """Try to open and return the network socket.
+        """
+        this_socket = socket.socket(family=socket.AF_INET,
+                                    type=socket.SOCK_STREAM,
+                                    proto=socket.IPPROTO_TCP)
+
+        # FIXME: double-check i don't need to do anything else in here...
+        #        recv-side needs to do a lot (bind, accept), but i think
+        #        send-side just needs to connect
+
+        # Try connecting
+        try:
+            this_socket.connect((self.destination, self.port))
+            return this_socket
+        except OSError as e:
+            logging.warning('Unable to connect to %s: %s', self.network, e)
+            return None
+
+    ############################
+    def write(self, record):
+        """Write the record to the network."""
+        # If we don't have a record, there's nothing to do
+        if not record:
+            return
+
+        # If we've got a list, hope it's a list of records. Recurse,
+        # calling write() on each of the list elements in order.
+        if isinstance(record, list):
+            for single_record in record:
+                self.write(single_record)
+            return
+
+        # Append eol if configured
+        if self.eol:
+            record += self.eol
+
+        # If socket isn't connected, try reconnecting. If we can't
+        # reconnect, complain and return without writing.
+        if not self.socket:
+            self.socket = self._open_socket()
+        if not self.socket:
+            logging.error('Unable to write record to %s:%d',
+                          self.destination, self.port)
+            return
+
+        num_tries = bytes_sent = 0
+        rec_len = len(record)
+        while num_tries <= self.num_retry and bytes_sent < rec_len:
+            try:
+                bytes_sent = self.socket.send(self._encode_str(record))
+                if self.num_warnings == self.warning_limit:
+                    logging.info('TCPWriter.write() succeeded in writing after series of'
+                                 'failures; resetting warnings.')
+                    self.num_warnings = 0 # we've succeeded
+
+            except OSError as e:
+                if self.num_warnings < self.warning_limit:
+                    logging.error('TCPWriter error: %s:%d: %s', self.destination, self.port, str(e))
+                    logging.error('TCPWriter record: %s', record)
+                    self.num_warnings += 1
+                    if self.num_warnings == self.warning_limit:
+                        logging.error('TCPWriter.write() - muting errors')
+            num_tries += 1
+
+        logging.debug('TCPWriter.write() wrote %d/%d bytes after %d tries',
+                      bytes_sent, rec_len, num_tries)

--- a/logger/writers/tcp_writer.py
+++ b/logger/writers/tcp_writer.py
@@ -16,17 +16,17 @@ from logger.writers.writer import Writer  # noqa: E402
 class TCPWriter(Writer):
     """Write TCP packtes to network."""
 
-    def __init__(self, port, destination,
+    def __init__(self, destination, port,
                  num_retry=2, warning_limit=5, eol='',
                  encoding='utf-8', encoding_errors='ignore'):
         """
         Write records to a TCP network socket.
 
         ```
-        port         Port to which packets should be sent
-
         destination  The destination to send TCP packets to.  Can be resolvable hostname
                      or valid IP address.
+
+        port         Port to which packets should be sent
 
         num_retry    Number of times to retry if write fails.
 

--- a/logger/writers/test_tcp_writer.py
+++ b/logger/writers/test_tcp_writer.py
@@ -10,7 +10,7 @@ import unittest
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
-from logger.writers.network_writer import NetworkWriter  # noqa: E402
+from logger.writers.tcp_writer import TCPWriter  # noqa: E402
 
 SAMPLE_DATA = ['f1 line 1',
                'f1 line 2',
@@ -28,7 +28,7 @@ class ReaderTimeout(StopIteration):
 ################################################################################
 
 
-class TestNetworkWriter(unittest.TestCase):
+class TestTCPWriter(unittest.TestCase):
     ############################
     def _handler(self, signum, frame):
         """If timeout fires, raise our custom exception"""
@@ -36,9 +36,9 @@ class TestNetworkWriter(unittest.TestCase):
         raise ReaderTimeout
 
     ############################
-    # Actually run the NetworkWriter in internal method
+    # Actually run the TCPWriter in internal method
     def write_tcp(self, dest_ip, dest_port, eol, encoding, sample_data, interval, delay):
-        writer = NetworkWriter(dest_port, dest_ip, eol=eol, encoding=encoding)
+        writer = TCPWriter(dest_port, dest_ip, eol=eol, encoding=encoding)
 
         time.sleep(delay)
         for line in sample_data:

--- a/logger/writers/test_tcp_writer.py
+++ b/logger/writers/test_tcp_writer.py
@@ -38,7 +38,7 @@ class TestTCPWriter(unittest.TestCase):
     ############################
     # Actually run the TCPWriter in internal method
     def write_tcp(self, dest_ip, dest_port, eol, encoding, sample_data, interval, delay):
-        writer = TCPWriter(dest_port, dest_ip, eol=eol, encoding=encoding)
+        writer = TCPWriter(dest_ip, dest_port, eol=eol, encoding=encoding)
 
         time.sleep(delay)
         for line in sample_data:

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -146,7 +146,7 @@ class UDPWriter(Writer):
         self.mc_interface = mc_interface
         self.mc_ttl = mc_ttl
 
-        # socket get's initialized on-demand in write()
+        # socket gets initialized on-demand in write()
         self.socket = None
 
     ############################

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -146,8 +146,8 @@ class UDPWriter(Writer):
         self.mc_interface = mc_interface
         self.mc_ttl = mc_ttl
 
-        # Try opening the socket
-        self.socket = self._open_socket()
+        # socket get's initialized on-demand in write()
+        self.socket = None
 
     ############################
     def _open_socket(self):
@@ -239,8 +239,7 @@ class UDPWriter(Writer):
                 # If we failed, complain, unless we've already complained too much
                 self.good_writes = 0
                 if self.num_warnings < self.warning_limit:
-                    logging.error('UDPWriter error: %s: %s', self.target_str, str(e))
-                    logging.error('UDPWriter record: %s', record)
+                    logging.error('UDPWriter: send() error: %s: %s', self.target_str, str(e))
                     self.num_warnings += 1
                     if self.num_warnings == self.warning_limit:
                         logging.error('UDPWriter.write() - muting errors')


### PR DESCRIPTION
Pablo, this branch should do exactly what we discussed for Issue #347.  The first couple commits are almost identical to changes made to UDPWriter last week, then it removes UDP from NetworkWriter, gets TCP working, renames it to TCPWriter, and leaves behind a noisy NetworkWriter class that just tells users to use UDPWriter or TCPWriter.
I've also added `--write_tcp` to `listen.py` and fixed encoding usage in there so it can use UDPWriter and TCPWriter with raw/binary data (should have done that previously, but didn't realize it existed).
Thanks!