### PR TITLE
Moved the api urls into their own urlpatterns list inside api_views.py

### DIFF
--- a/django_gui/urls.py
+++ b/django_gui/urls.py
@@ -17,45 +17,23 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
-from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from . import views
-from . import api_views
-
 
 urlpatterns = [
     path('', views.index, name='index'),
-    path('admin/', admin.site.urls),
-    path('accounts/', include('django.contrib.auth.urls')),
-    # path('login/', auth_views.login, name='login'),
-    # path('logout/', auth_views.logout,
-    #    {'next_page': '../'}, name='logout'),
+    path('admin/', admin.site.urls),    
+    path('accounts/', include('django.contrib.auth.urls')),    
+    
+    #api_Views.py
+    path('api/', include('django_gui.api_views')),
+
+    # Views.py    
     path('login/', views.login_user, name='login_user'),
-    path('change_mode/',
-         views.change_mode, name='change_mode'),
-    path('edit_config/<str:logger_id>',
-         views.edit_config, name='edit_config'),
+    path('change_mode/', views.change_mode, name='change_mode'),
+    path('edit_config/<str:logger_id>', views.edit_config, name='edit_config'),
     path('choose_file/', views.choose_file, name='choose_file'),
     path('widget/<str:field_list>', views.widget, name='widget'),
     path('widget/', views.widget, name='widget'),
     path('fields/', views.fields, name='fields'),
-    #
-    #API Dango REST Framework Views
-    #
-    # DRF Spectacular urls.
-    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
-    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
-    # These are the login and logout restframework urls
-    path('api/', include('rest_framework.urls', namespace='rest_framework')),
-    # Token Auth
-    path('api/obtain-auth-token/', api_views.CustomAuthToken.as_view(), name="obtain-auth-token"),
-    # These are the DRF API stubbs
-    # flake8: noqa E501
-    path('api/', api_views.api_root),
-    path('api/cruise-configuration/', api_views.CruiseConfigurationAPIView.as_view(), name='cruise-configuration'),
-    path('api/delete-configuration/', api_views.CruiseDeleteConfigurationAPIView.as_view(), name='delete-configuration'),
-    path('api/edit-logger-config/', api_views.EditLoggerConfigAPIView.as_view(), name='edit-logger-config'),
-    path('api/load-configuration-file/', api_views.LoadConfigurationFileAPIView.as_view(), name='load-configuration-file'),
-    path('api/reload-current-configuration/', api_views.CruiseReloadCurrentConfigurationAPIView.as_view(), name='reload-current-configuration'),
-    path('api/select-cruise-mode/', api_views.CruiseSelectModeAPIView.as_view(), name='select-cruise-mode')
+  
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
This all the api_code and complexity in one file. and makes the standard django_gui urls file simpler as the import for the api views is just path('api/', include('django_gui.api_views')),