### PR TITLE
Refactor of Transform class to handle cross cutting concerns

### DIFF
--- a/logger/transforms/base_transform.py
+++ b/logger/transforms/base_transform.py
@@ -7,7 +7,7 @@ from logger.utils import formats  # noqa: E402
 
 
 ################################################################################
-class Transform:
+class BaseTransform:
     """
     Base class Transform about which we know nothing else. By default the
     input and output formats are Unknown unless overridden.
@@ -44,7 +44,15 @@ class Transform:
 
     ############################
     def transform(self, record):
-        """Should return None if the result of transformation is empty record"""
-        raise NotImplementedError('Class %s (subclass of Transform) is missing '
-                                  'implementation of transform() method.'
+        if record is None:
+            return None
+        if isinstance(record, list):
+            return [self.transform(single_record) for single_record in record]
+
+        return self._transform_single_record(record)
+
+    ############################
+    def _transform_single_record(self, record):
+        raise NotImplementedError('Class %s (subclass of BaseTransform) is missing '
+                                  'implementation of _transform_single() method.'
                                   % self.__class__.__name__)

--- a/logger/transforms/count_transform.py
+++ b/logger/transforms/count_transform.py
@@ -7,12 +7,12 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class CountTransform(Transform):
+class CountTransform(BaseTransform):
     """Return number of times the passed fields have been seen as a dict
     (or DASRecord, depending on what was passed in) where the keys are
     'field_name:count' and the values are the number of times the passed
@@ -33,20 +33,8 @@ class CountTransform(Transform):
         self.counts = {}
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Return counts of the previous times we've seen these field names."""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(record) is DASRecord:
             fields = record.fields
         elif type(record) is dict:

--- a/logger/transforms/delta_transform.py
+++ b/logger/transforms/delta_transform.py
@@ -1,5 +1,6 @@
 import logging
 
+from logger.transforms.base_transform import BaseTransform
 from logger.utils.das_record import DASRecord  # noqa: E402
 
 KNOWN_FIELD_TYPES = ['polar']
@@ -11,7 +12,7 @@ def polar_diff(last_value, value):
 
 
 ################################################################################
-class DeltaTransform:
+class DeltaTransform(BaseTransform):
     def __init__(self, rate=False, field_type=None):
         """Return a DASRecord (or dict, depending on input record type) with
         each field's delta in value from it's previous value. If a field
@@ -49,12 +50,7 @@ class DeltaTransform:
         self.last_value_dict = {}
 
     ############################
-    def transform(self, record):
-        if not record:
-            return None
-
-        fields = {}
-
+    def _transform_single_record(self, record):
         if type(record) is DASRecord:
             fields = record.fields
             timestamp = record.timestamp
@@ -62,12 +58,6 @@ class DeltaTransform:
         elif type(record) is dict:
             fields = record.get('fields', None)
             timestamp = record.get('timestamp', None)
-
-        elif type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
 
         else:
             logging.info('Record passed to DeltaTransform was neither a dict nor a '

--- a/logger/transforms/derived_data_transform.py
+++ b/logger/transforms/derived_data_transform.py
@@ -4,11 +4,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class DerivedDataTransform(Transform):
+class DerivedDataTransform(BaseTransform):
     """Trivial base class for derived data transforms. Derived data
     transforms used to have some complicated invocation process to make
     them more efficient, but we've opted to make them just like any

--- a/logger/transforms/extract_field_transform.py
+++ b/logger/transforms/extract_field_transform.py
@@ -6,12 +6,12 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class ExtractFieldTransform(Transform):
+class ExtractFieldTransform(BaseTransform):
     """Extract a field from passed DASRecord or dict.
     """
 
@@ -21,21 +21,9 @@ class ExtractFieldTransform(Transform):
         self.field_name = field_name
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Extract the specified field from the passed DASRecord or dict.
         """
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(record) is DASRecord:
             return record.fields.get(self.field_name, None)
         elif type(record) is dict:

--- a/logger/transforms/format_transform.py
+++ b/logger/transforms/format_transform.py
@@ -42,11 +42,11 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils.das_record import DASRecord  # noqa: E402
 from logger.utils.timestamp import time_str  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class FormatTransform(Transform):
+class FormatTransform(BaseTransform):
     def __init__(self, format_str, defaults=None, use_iso_timestamp=False):
         """
         Output a formatted string in which field values from a DASRecord or field
@@ -83,20 +83,8 @@ class FormatTransform(Transform):
         self.defaults = defaults or {}
         self.use_uso_timestamp = use_iso_timestamp
 
-    def transform(self, record):
+    def _transform_single_record(self, record):
         # Make sure record is right format - DASRecord or dict
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(record) is DASRecord:
             record_fields = record.fields
         elif type(record) is dict:

--- a/logger/transforms/from_json_transform.py
+++ b/logger/transforms/from_json_transform.py
@@ -8,12 +8,12 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class FromJSONTransform(Transform):
+class FromJSONTransform(BaseTransform):
     """Convert passed JSON to either a DASRecord or a dict.
     """
 
@@ -28,20 +28,8 @@ class FromJSONTransform(Transform):
         self.das_record = das_record
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Parse JSON record to Python data struct or DASRecord."""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if not type(record) is str:
             logging.warning('FromJSON transform received non-string input, '
                             'type: "%s"', type(record))

--- a/logger/transforms/max_min_transform.py
+++ b/logger/transforms/max_min_transform.py
@@ -7,12 +7,12 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class MaxMinTransform(Transform):
+class MaxMinTransform(BaseTransform):
     """Transform that returns None unless values in passed DASRecord or
     dict are greater than/less than the largest/smallest values seen for
     their respective variables. Otherwise returns dict of colon-suffixed
@@ -36,20 +36,8 @@ class MaxMinTransform(Transform):
         self.min = {}
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Does record exceed any previously-observed bounds?"""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(record) is DASRecord:
             fields = record.fields
         elif type(record) is dict:

--- a/logger/transforms/nmea_checksum_transform.py
+++ b/logger/transforms/nmea_checksum_transform.py
@@ -3,6 +3,7 @@ import logging
 # For efficient checksum code
 from functools import reduce
 from operator import xor
+from logger.transforms.base_transform import BaseTransform
 
 
 ############################
@@ -38,7 +39,7 @@ def compute_checksum(source):
 
 
 ################################################################################
-class NMEAChecksumTransform:
+class NMEAChecksumTransform(BaseTransform):
     """
     NMEAChecksumTransform checks the integrity/completeness of a record by confirming
     whether or not the checksum matches. If the checksum matches, it returns the record,
@@ -70,16 +71,13 @@ class NMEAChecksumTransform:
                               'write() method!')
                 self.writer = None
 
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """
         Checks if computed checksum matches parsed checksum. If True, it returns the record,
         otherwise it calls send_error_message().
 
         record - the record in question
         """
-        if not record:
-            return None
-
         if not type(record) is str:
             logging.warning('NMEAChecksumTransform passed non-string record '
                             '(type %s): %s', type(record), record)

--- a/logger/transforms/nmea_transform.py
+++ b/logger/transforms/nmea_transform.py
@@ -29,6 +29,7 @@ import inspect
 # For efficient checksum code
 from functools import reduce
 from operator import xor
+from logger.transforms.base_transform import BaseTransform
 
 
 ############################
@@ -38,7 +39,7 @@ def checksum(source):
 
 
 ################################################################################
-class NMEATransform:
+class NMEATransform(BaseTransform):
     """Call our various component transforms and generate NMEA strings from them.
     """
 
@@ -129,7 +130,7 @@ direction, so omit if not available.
 ################################################################################
 
 
-class MWDTransform:
+class MWDTransform(BaseTransform):
     """Output a NMEA MWD string, given true wind and (when available)
     magnetic variation.
     """
@@ -166,7 +167,7 @@ class MWDTransform:
         self.magnetic_variation = None
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Incorporate any useable fields in this record. If it gives us a
         new MWD record, return it.
         """
@@ -260,7 +261,7 @@ TextFileWriter, for example) acting appropriately.
 ################################################################################
 
 
-class XDRTransform:
+class XDRTransform(BaseTransform):
     """Output a NMEA XDR string, given whatever variables we can find.
     """
 
@@ -300,7 +301,7 @@ class XDRTransform:
         self.xdr_talker_id = kwargs.get('xdr_talker_id', None)
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Incorporate any useable fields in this record, and if it gives us a
         new true wind value, return the results.
         """
@@ -341,7 +342,7 @@ class XDRTransform:
 
 ################################################################################
 
-class DPTTransform:
+class DPTTransform(BaseTransform):
     """Take in records and emit a NMEA DPT string, as per format:
       $--DPT,x.x,x.x,*nn<CR><LF> \\
     Field Number:
@@ -375,7 +376,7 @@ class DPTTransform:
         self.dpt_talker_id = kwargs.get('dpt_talker_id', None)
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Incorporate any useable fields in this record, and if it gives us a
         new true wind value, return the results.
         """
@@ -386,7 +387,7 @@ class DPTTransform:
             return None
         fields = record.get('fields', None)
         if not fields:
-            logging.debug('MWDTransform got record with no fields: %s', record)
+            logging.debug('DPTTransform got record with no fields: %s', record)
             return None
 
         depth = fields.get(self.depth_field)
@@ -402,7 +403,7 @@ class DPTTransform:
 
 ################################################################################
 
-class STNTransform:
+class STNTransform(BaseTransform):
     """This sentence is transmitted before each individual sentence where there is a need for the
     Listener to determine the exact source of data in the system. Examples might include
     dual-frequency depth sounding equipment or equipment that integrates data from a
@@ -433,7 +434,7 @@ class STNTransform:
         self.stn_talker_id = kwargs.get('stn_talker_id', None)
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Incorporate any useable fields in this record.
         """
         # Check that we've got the right record type - it should be a
@@ -443,7 +444,7 @@ class STNTransform:
             return None
         fields = record.get('fields', None)
         if not fields:
-            logging.debug('MWDTransform got record with no fields: %s', record)
+            logging.debug('STNTransform got record with no fields: %s', record)
             return None
 
         id = fields.get(self.id_field)

--- a/logger/transforms/parse_nmea_transform.py
+++ b/logger/transforms/parse_nmea_transform.py
@@ -6,11 +6,11 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils import nmea_parser  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class ParseNMEATransform(Transform):
+class ParseNMEATransform(BaseTransform):
     """Parse a "<data_id> <timestamp> <nmea>" record and return
     corresponding DASRecord."""
 
@@ -37,20 +37,8 @@ class ParseNMEATransform(Transform):
                                              time_format=time_format)
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Parse record and return DASRecord."""
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         result = self.parser.parse_record(record)
         if not result:
             return None

--- a/logger/transforms/parse_transform.py
+++ b/logger/transforms/parse_transform.py
@@ -5,11 +5,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import record_parser  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class ParseTransform(Transform):
+class ParseTransform(BaseTransform):
     """Parse a "<data_id> <timestamp> <message>" record and return
     corresponding dict of values (or JSON or DASRecord if specified)."""
 
@@ -79,18 +79,6 @@ class ParseTransform(Transform):
             delimiter=delimiter)
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Parse record and return DASRecord."""
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         return self.parser.parse_record(record)

--- a/logger/transforms/prefix_transform.py
+++ b/logger/transforms/prefix_transform.py
@@ -6,11 +6,11 @@ import sys
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class PrefixTransform(Transform):
+class PrefixTransform(BaseTransform):
     """Prepend a prefix to a text record."""
 
     def __init__(self, prefix, sep=' ', quiet=False):
@@ -46,20 +46,8 @@ class PrefixTransform(Transform):
         self.quiet = quiet
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Prepend a prefix."""
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(self.prefix) is str:
             return self.prefix + record
 

--- a/logger/transforms/qc_filter_transform.py
+++ b/logger/transforms/qc_filter_transform.py
@@ -13,12 +13,12 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class QCFilterTransform(Transform):
+class QCFilterTransform(BaseTransform):
     """
     Transform that returns None unless values in passed DASRecord are out of
     bounds, in which case return a warning message."""
@@ -53,20 +53,8 @@ class QCFilterTransform(Transform):
                                  'Found "%s" instead.' % condition)
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Does record violate any bounds?"""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(record) is DASRecord:
             fields = record.fields
         elif type(record) is dict:

--- a/logger/transforms/regex_filter_transform.py
+++ b/logger/transforms/regex_filter_transform.py
@@ -6,11 +6,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class RegexFilterTransform(Transform):
+class RegexFilterTransform(BaseTransform):
     """Only return records matching the specified regular expression."""
     ############################
 
@@ -21,20 +21,8 @@ class RegexFilterTransform(Transform):
         self.negate = negate
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Does record contain pattern?"""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         match = self.pattern.search(record)
         if match is None:
             if self.negate:

--- a/logger/transforms/regex_replace_transform.py
+++ b/logger/transforms/regex_replace_transform.py
@@ -6,11 +6,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class RegexReplaceTransform(Transform):
+class RegexReplaceTransform(BaseTransform):
     """Apply regex replacements to record."""
     ############################
 
@@ -26,20 +26,8 @@ class RegexReplaceTransform(Transform):
         self.flags = flags
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Does record contain pattern?"""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         # Apply all patterns in order
         result = record
         for old_str, new_str in self.patterns.items():

--- a/logger/transforms/select_fields_transform.py
+++ b/logger/transforms/select_fields_transform.py
@@ -10,11 +10,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class SelectFieldsTransform(Transform):
+class SelectFieldsTransform(BaseTransform):
     """Cull key:value pairs from a record's field dict. Can accept a
     top-level dict, a field dict or a DASRecord, and will return a
     record in the same format as it received.
@@ -47,7 +47,7 @@ class SelectFieldsTransform(Transform):
                             '"delete" arguments will be ignored.')
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """
         Return a copy of the passed record with the relevant fields kept/deleted.
         """
@@ -67,14 +67,6 @@ class SelectFieldsTransform(Transform):
         # we're going to pass records through unchanged.
         if self.keep and self.delete:
             return new_record
-
-        # If we've got a list, hope it's a list of records. Try to add
-        # them all.
-        if type(new_record) is list:
-            new_record_list = []
-            for single_new_record in new_record:
-                new_record_list.append(self.transform(single_new_record))
-            return new_record_list
 
         # If it's a dict, hope it's a single record.
         elif type(new_record) is DASRecord:

--- a/logger/transforms/slice_transform.py
+++ b/logger/transforms/slice_transform.py
@@ -7,11 +7,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class SliceTransform(Transform):
+class SliceTransform(BaseTransform):
     def __init__(self, fields=None, sep=None):
         """
         ```
@@ -64,20 +64,8 @@ class SliceTransform(Transform):
             raise e
 
     ############################
-    def transform(self, record):
-        """Strip and return only the requested fields."""
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
+    def _transform_single_record(self, record):
+        """Split record into array of records along separator."""
         if not type(record) is str:
             logging.warning('SliceTransform received non-string input: %s', record)
             return None

--- a/logger/transforms/split_transform.py
+++ b/logger/transforms/split_transform.py
@@ -6,11 +6,11 @@ import sys
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class SplitTransform(Transform):
+class SplitTransform(BaseTransform):
     def __init__(self, sep='\n'):
         """
         ```
@@ -20,20 +20,9 @@ class SplitTransform(Transform):
         self.sep = sep
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Split record into array of records along separator."""
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results += self.transform(single_record)
-
-        elif not type(record) is str:
+        if not type(record) is str:
             logging.warning('SplitTransform received non-string input: %s', record)
             results = None
 

--- a/logger/transforms/strip_transform.py
+++ b/logger/transforms/strip_transform.py
@@ -6,11 +6,11 @@ import sys
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class StripTransform(Transform):
+class StripTransform(BaseTransform):
     def __init__(self, chars=None, unprintable=False,
                  strip_prefix=False, strip_suffix=False):
         """
@@ -38,20 +38,8 @@ class StripTransform(Transform):
         self.strip_suffix = strip_suffix
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Strip and return only the requested fields."""
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if not type(record) is str:
             logging.warning('SplitTransform received non-string input: %s', record)
             return None

--- a/logger/transforms/subsample_transform.py
+++ b/logger/transforms/subsample_transform.py
@@ -131,20 +131,10 @@ class SubsampleTransform(DerivedDataTransform):
                     break
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Incorporate any useable fields in this record, and if it gives
         us any new subsampled values, aggregate and return them.
         """
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         # Clean out old data
         self._add_record(record)
 

--- a/logger/transforms/timestamp_transform.py
+++ b/logger/transforms/timestamp_transform.py
@@ -6,14 +6,14 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils import timestamp  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 """Prepend a timestamp to a text record."""
 
 
-class TimestampTransform(Transform):
+class TimestampTransform(BaseTransform):
     def __init__(self, time_format=timestamp.TIME_FORMAT,
                  time_zone=timestamp.timezone.utc, sep=' '):
         """If timestamp_format is not specified, use default format"""

--- a/logger/transforms/to_das_record_transform.py
+++ b/logger/transforms/to_das_record_transform.py
@@ -7,12 +7,12 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class ToDASRecordTransform(Transform):
+class ToDASRecordTransform(BaseTransform):
     """Convert passed record to DASRecord. If initialized with a
     field_name, expect to be passed strings, and use those strings as
     the corresponding field values. Otherwise, expect a dict, and use it
@@ -26,20 +26,8 @@ class ToDASRecordTransform(Transform):
         self.field_name = field_name
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Convert record to DASRecord."""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if self.field_name:
             if type(record) is str:
                 das_record = DASRecord(data_id=self.data_id, fields={self.field_name: record})

--- a/logger/transforms/to_json_transform.py
+++ b/logger/transforms/to_json_transform.py
@@ -8,12 +8,12 @@ from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class ToJSONTransform(Transform):
+class ToJSONTransform(BaseTransform):
     """Convert passed DASRecords, lists or dicts to JSON. If pretty == True,
     format the JSON output for easy reading.
     """
@@ -25,20 +25,8 @@ class ToJSONTransform(Transform):
         self.pretty = pretty
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Convert record to JSON."""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(record) is DASRecord:
             return record.as_json(self.pretty)
 

--- a/logger/transforms/true_winds_transform.py
+++ b/logger/transforms/true_winds_transform.py
@@ -184,22 +184,9 @@ class TrueWindsTransform(DerivedDataTransform):
         return metadata_fields
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Incorporate any useable fields in this record, and if it gives
         us a new true wind value, return the results."""
-
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         results = []
         for das_record in to_das_record_list(record):
             # If they haven't specified specific fields we should wait for

--- a/logger/transforms/unique_transform.py
+++ b/logger/transforms/unique_transform.py
@@ -8,11 +8,11 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class UniqueTransform(Transform):
+class UniqueTransform(BaseTransform):
     """Return the record only if it has changed from the previous value."""
 
     def __init__(self):
@@ -21,7 +21,7 @@ class UniqueTransform(Transform):
         self.prev_record = ""
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """If same as previous, return None, else record."""
         if record == self.prev_record:
             return None

--- a/logger/transforms/value_filter_transform.py
+++ b/logger/transforms/value_filter_transform.py
@@ -13,12 +13,12 @@ import sys
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
 #
-class ValueFilterTransform(Transform):
+class ValueFilterTransform(BaseTransform):
     """
     Transform that filters out values in a passed DASRecord that are out of bounds."""
 
@@ -68,20 +68,8 @@ class ValueFilterTransform(Transform):
         self.log_level = log_level
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Does record violate any bounds?"""
-        if not record:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         if type(record) is DASRecord:
             fields = record.fields
         elif type(record) is dict:

--- a/logger/transforms/xml_aggregator_transform.py
+++ b/logger/transforms/xml_aggregator_transform.py
@@ -10,11 +10,11 @@ from xml.sax import make_parser
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import formats  # noqa: E402
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 
 
 ################################################################################
-class XMLAggregatorTransform(Transform):
+class XMLAggregatorTransform(BaseTransform):
     """Aggregate passed lines of XML until a complete XML record whose
     outermost element matches 'tag' has been seen, then pass it on as a
     single record."""
@@ -39,20 +39,8 @@ class XMLAggregatorTransform(Transform):
         self.parser.setContentHandler(self.handler)
 
     ############################
-    def transform(self, record):
+    def _transform_single_record(self, record):
         """Aggregate, returning None until we're done, then return record."""
-        if record is None:
-            return None
-
-        # If we've got a list, hope it's a list of records. Recurse,
-        # calling transform() on each of the list elements in order and
-        # return the resulting list.
-        if type(record) is list:
-            results = []
-            for single_record in record:
-                results.append(self.transform(single_record))
-            return results
-
         with self.buffer_lock:
             # Feed record to the incremental parser
             self.buffer += record + '\n'

--- a/test/logger/transforms/test_base_transform.py
+++ b/test/logger/transforms/test_base_transform.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 
 sys.path.append('.')
-from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.base_transform import BaseTransform  # noqa: E402
 from logger.utils import formats  # noqa: E402
 
 
@@ -13,8 +13,8 @@ class TestTransform(unittest.TestCase):
     ############################
     # Check that transform input/output_formats work the way we expect
     def test_formats(self):
-        transform = Transform(input_format=formats.Text,
-                              output_format=formats.Text)
+        transform = BaseTransform(input_format=formats.Text,
+                                  output_format=formats.Text)
 
         self.assertEqual(transform.input_format(), formats.Text)
         self.assertEqual(transform.input_format(formats.NMEA), formats.NMEA)


### PR DESCRIPTION
…oss-cutting concerns

* Transform class renamed to BaseTransform to better reflect its purpose
* BaseTransform's transform method now handles None check and recursion cross-cutting concerns
* Most concrete transform classes now override the _transform_single_record method, with recursion and None checks handled by the base transform

Some concrete transforms still override the transform method rather than the new _transform_single_record
* TimestampTransform, due to the ts param
* InterpolationTransform, due to its unique _add_record logic
* NMEATransform, due to its iterative logic