### PR TITLE
Issue 458

### DIFF
--- a/logger/writers/file_writer.py
+++ b/logger/writers/file_writer.py
@@ -162,7 +162,7 @@ class FileWriter(Writer):
             #     stacklevel=2,
             # )
         if split_by_time:
-            split_interval = '24H'
+            split_interval = split_interval or '24H'
             # warnings.warn(
             #     "`split_by_time` is deprecated, use `split_interval` instead",
             #     DeprecationWarning,


### PR DESCRIPTION
There is an edge case where if `split_by_time` and `split_interval` were declared, the split_interval would always be set to 24H.  This change ensures the `split_interval` is used regardless if `split_by_time` is specified.