### PR TITLE
SOI UI tweaks

### DIFF
--- a/django_gui/static/django_gui/index.html.js
+++ b/django_gui/static/django_gui/index.html.js
@@ -287,7 +287,7 @@ function update_cruise_definition(timestamp, cruise_definition) {
     var stderr_div = document.createElement('div');
 
     stderr_div.setAttribute('id', logger_name + '_stderr');
-    stderr_div.setAttribute('style', 'height:30px;width:450px;background-color:white;padding:0px;overflow-y:auto;');
+    stderr_div.setAttribute('style', 'height:30px;width:450px;background-color:white;padding:0px;overflow-y:auto;resize:both;');
     stderr_div.style.fontSize = 'x-small';
     stderr_td.appendChild(stderr_div);
     tr.appendChild(stderr_td);

--- a/django_gui/static/django_gui/stderr_log_utils.js
+++ b/django_gui/static/django_gui/stderr_log_utils.js
@@ -54,7 +54,7 @@ function process_stderr_message(target_div_id, log_line_list) {
 function color_log_line(message) {
   var color = '';
   if (message.indexOf(' 30 WARNING ') > 0) {
-    color = 'gold';
+    color = '#e09100';
   } else if (message.indexOf(' 40 ERROR ') > 0) {
     color = 'orange';
   } else if (message.indexOf(' 50 CRITICAL ') > 0) {

--- a/django_gui/templates/django_gui/index.html
+++ b/django_gui/templates/django_gui/index.html
@@ -30,6 +30,7 @@
         padding:0px;
         overflow-y:auto;
         font-size:x-small;
+        resize:both;
     }
 </style>
 


### PR DESCRIPTION
Consider couple one-liners that have improved my daily relationship with OpenRVDAS

With a single resize:both CSS flag we can make all the stderr boxes user resizable - and I personally use these dragging controls practically every day.

text-color:gold seems to be a particularly fuzzy rendering color while #e09100 seems to be a lot more readable at the same size. Granted now warning and error are very similar colors but I guess both should be taken seriously.

<img width="780" height="825" alt="image" src="https://github.com/user-attachments/assets/79a6ed90-9a9b-4524-ab24-35212d14fcb4" />
