### PR TITLE
Issue 457 (#467)

### DIFF
--- a/logger/writers/google_sheets_writer.py
+++ b/logger/writers/google_sheets_writer.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""
+GoogleSheetsWriter - A Python class for writing dictionaries to Google Sheets
+
+This module provides a simple interface for writing Python dictionaries as rows
+to Google Sheets, with automatic column creation and management.
+
+Author: Assistant
+License: MIT
+"""
+
+from googleapiclient.discovery import build
+from google.oauth2.service_account import Credentials
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials as UserCredentials
+import os
+import sys
+
+from os.path import dirname, realpath
+
+sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
+from logger.utils.das_record import DASRecord  # noqa: E402
+from logger.writers.writer import Writer  # noqa: E402
+
+
+class GoogleSheetsWriter(Writer):
+    """
+    A class for writing Python dictionaries as rows to Google Sheets
+    with automatic column management.
+
+    This class handles authentication, column creation, and data writing to Google Sheets.
+    Each dictionary key becomes a column header, and each dictionary becomes a row.
+    New columns are automatically created when new keys are encountered.
+    Numeric values are preserved as numbers in the spreadsheet.
+
+    SETUP INSTRUCTIONS:
+
+    1. Install Required Packages:
+       pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
+
+    2. Set Up Google Cloud Project:
+       - Go to https://console.cloud.google.com/
+       - Create a new project or select existing one
+       - Note your project ID
+
+    3. Enable Google Sheets API:
+       - In Cloud Console, go to "APIs & Services" > "Library"
+       - Search for "Google Sheets API"
+       - Click on it and press "Enable"
+
+    4. Create Service Account:
+       - Go to "APIs & Services" > "Credentials"
+       - Click "Create Credentials" > "Service Account"
+       - Enter service account name (e.g., "sheets-writer-bot")
+       - Click "Create and Continue"
+       - Skip role assignment (click "Continue")
+       - Skip user access (click "Done")
+
+    5. Generate JSON Key File:
+       - Find your service account in the credentials list
+       - Click on it to open details
+       - Go to "Keys" tab
+       - Click "Add Key" > "Create New Key"
+       - Select "JSON" format and click "Create"
+       - Save the downloaded JSON file securely (never commit to version control!)
+
+    6. Share Your Spreadsheet:
+       - Open your Google Sheets document
+       - Click "Share" button
+       - Enter the service account email (client_email from JSON file)
+       - Give "Editor" permissions
+       - Uncheck "Notify people"
+       - Click "Share"
+
+    EXAMPLE USAGE:
+
+        # Initialize writer with force_create enabled
+        writer = GoogleSheetsWriter(
+            sheet_name_or_id="1ABC123def456...",  # Your spreadsheet ID
+            auth_key_path="path/to/service-account-key.json",
+            use_service_account=True,
+            worksheet_name="MyData",
+            force_create=True  # Will create "MyData" worksheet if it doesn't exist
+        )
+
+        # Write single dictionary (timestamp automatically goes first)
+        writer.write({'timestamp': 1234567890, 'name': 'John', 'age': 30})
+
+        # Write single DASRecord (uses DASRecord.timestamp automatically)
+        from das_record import DASRecord
+        das_record = DASRecord(timestamp=1234567891, fields={'name': 'Jane', 'age': 25})
+        writer.write(das_record)
+
+        # Write multiple records (mixed types)
+        records = [
+            {'timestamp': 1234567892, 'name': 'Bob', 'city': 'NYC', 'salary': 75000.50},
+            DASRecord(timestamp=1234567893, fields={'name': 'Alice', 'department': 'Engineering', 'rating': 4.8})
+        ]
+        writer.write(records)
+
+    SECURITY NOTES:
+    - Never commit the JSON key file to version control
+    - Store the key file securely and use environment variables in production
+    - Limit service account permissions to only what's needed
+    - Consider key rotation for long-term production use
+
+    Attributes:
+        sheet_id (str): The Google Sheets spreadsheet ID
+        headers (list): Current column headers in the sheet
+        worksheet_name (str): Name of the worksheet/tab being used
+        force_create (bool): Whether to create the worksheet if it doesn't exist
+        service: Google Sheets API service object
+    """
+
+    def __init__(self, sheet_name_or_id, auth_key_path=None,
+                 use_service_account=True, worksheet_name="Sheet1", force_create=False):
+        """
+        Initialize GoogleSheetsWriter with spreadsheet name/ID and authentication.
+
+        Args:
+            sheet_name_or_id (str): Google Sheets spreadsheet ID, full URL, or name
+                                  Examples:
+                                  - "1ABC123def456ghi789..." (spreadsheet ID)
+                                  - "https://docs.google.com/spreadsheets/d/1ABC123.../edit"
+            auth_key_path (str): Path to service account JSON key file or OAuth credentials file
+                               If None and use_service_account=False, looks for 'token.json'
+            use_service_account (bool): True for service account auth, False for OAuth user auth
+            worksheet_name (str): Name of the specific worksheet/tab to write to (default: "Sheet1")
+            force_create (bool): If True, create the worksheet if it doesn't exist (default: False)
+
+        Raises:
+            ValueError: If authentication parameters are invalid
+            Exception: If unable to authenticate or access the spreadsheet
+        """
+        self.sheet_name_or_id = sheet_name_or_id
+        self.auth_key_path = auth_key_path
+        self.use_service_account = use_service_account
+        self.worksheet_name = worksheet_name
+        self.force_create = force_create
+        self.service = None
+        self.sheet_id = None
+        self.headers = []
+
+        # Initialize the service
+        self._authenticate()
+        self._get_sheet_id()
+        self._ensure_worksheet_exists()
+        self._load_existing_headers()
+
+    def _authenticate(self):
+        """
+        Authenticate and build the Google Sheets service.
+
+        Sets up authentication using either service account credentials or OAuth user credentials.
+        Creates the Google Sheets API service object for making requests.
+
+        Raises:
+            ValueError: If authentication credentials are missing or invalid
+        """
+        scopes = ['https://www.googleapis.com/auth/spreadsheets']
+
+        if self.use_service_account:
+            # Service account authentication
+            if not self.auth_key_path:
+                raise ValueError("Service account key file path is required")
+
+            credentials = Credentials.from_service_account_file(
+                self.auth_key_path, scopes=scopes
+            )
+        else:
+            # OAuth user credentials
+            creds = None
+            token_path = self.auth_key_path or 'token.json'
+
+            if os.path.exists(token_path):
+                creds = UserCredentials.from_authorized_user_file(token_path, scopes)
+
+            if not creds or not creds.valid:
+                if creds and creds.expired and creds.refresh_token:
+                    creds.refresh(Request())
+                else:
+                    raise ValueError("Valid OAuth credentials not found. Run OAuth flow first.")
+
+            credentials = creds
+
+        self.service = build('sheets', 'v4', credentials=credentials)
+
+    def _get_sheet_id(self):
+        """
+        Extract or find the spreadsheet ID from various input formats.
+
+        Handles different input formats:
+        - Direct spreadsheet ID: "1ABC123def456..."
+        - Full Google Sheets URL: "https://docs.google.com/spreadsheets/d/1ABC123.../edit"
+        - Assumes other inputs are spreadsheet IDs
+
+        Sets self.sheet_id to the extracted spreadsheet ID.
+        """
+        # If it looks like a spreadsheet ID (long alphanumeric string), use it directly
+        if len(self.sheet_name_or_id) > 20 and '/' not in self.sheet_name_or_id:
+            self.sheet_id = self.sheet_name_or_id
+        else:
+            # If it's a full URL, extract the ID
+            if 'docs.google.com/spreadsheets/d/' in self.sheet_name_or_id:
+                self.sheet_id = self.sheet_name_or_id.split('/d/')[1].split('/')[0]
+            else:
+                # Assume it's a spreadsheet ID
+                self.sheet_id = self.sheet_name_or_id
+
+    def _ensure_worksheet_exists(self):
+        """
+        Ensure the specified worksheet exists, creating it if necessary and force_create is True.
+
+        Checks if the worksheet exists in the spreadsheet. If force_create is True and the
+        worksheet doesn't exist, creates it.
+
+        Raises:
+            Exception: If worksheet doesn't exist and force_create is False, or if creation fails
+        """
+        try:
+            # Get spreadsheet metadata to check existing worksheets
+            spreadsheet = self.service.spreadsheets().get(
+                spreadsheetId=self.sheet_id
+            ).execute()
+
+            # Check if the worksheet already exists
+            existing_sheets = [sheet['properties']['title']
+                               for sheet in spreadsheet.get('sheets', [])]
+
+            if self.worksheet_name in existing_sheets:
+                # Worksheet exists, nothing to do
+                return
+
+            if not self.force_create:
+                # Worksheet doesn't exist and we're not allowed to create it
+                raise Exception(f"Worksheet '{self.worksheet_name}' does not exist in spreadsheet. "
+                                f"Set force_create=True to create it automatically.")
+
+            # Create the worksheet
+            requests = [{
+                'addSheet': {
+                    'properties': {
+                        'title': self.worksheet_name
+                    }
+                }
+            }]
+
+            body = {'requests': requests}
+
+            self.service.spreadsheets().batchUpdate(
+                spreadsheetId=self.sheet_id,
+                body=body
+            ).execute()
+
+            print(f"Created worksheet '{self.worksheet_name}' in spreadsheet")
+
+        except Exception as e:
+            if "force_create=True" in str(e):
+                # Re-raise our custom error message
+                raise e
+            else:
+                raise Exception(f"Failed to ensure worksheet exists: {str(e)}")
+
+    def _load_existing_headers(self):
+        """
+        Load existing column headers from the first row of the worksheet.
+
+        Reads the first row of the specified worksheet to get current column headers.
+        If the sheet is empty or doesn't exist, initializes with empty headers list.
+
+        Sets self.headers to the list of existing column headers.
+        """
+        try:
+            # Get the first row to see existing headers
+            range_name = f"{self.worksheet_name}!1:1"
+            result = self.service.spreadsheets().values().get(
+                spreadsheetId=self.sheet_id,
+                range=range_name
+            ).execute()
+
+            values = result.get('values', [])
+            if values:
+                self.headers = values[0]
+            else:
+                self.headers = []
+
+        except Exception as e:
+            print(f"Warning: Could not load existing headers: {str(e)}")
+            self.headers = []
+
+    def _update_headers(self, new_keys):
+        """
+        Add new column headers for any keys not already present.
+
+        Compares the provided keys with existing headers and adds any new ones
+        to both the local headers list and the spreadsheet's first row.
+
+        Args:
+            new_keys (iterable): Keys from a dictionary that should be column headers
+
+        Side Effects:
+            - Updates self.headers with any new column names
+            - Updates the first row of the spreadsheet with new headers
+        """
+        # Find keys that aren't already headers
+        new_headers = [key for key in new_keys if key not in self.headers]
+
+        if new_headers:
+            # Add new headers to our list
+            self.headers.extend(new_headers)
+
+            # Update the header row in the sheet
+            range_name = f"{self.worksheet_name}!1:1"
+            body = {
+                'values': [self.headers]
+            }
+
+            self.service.spreadsheets().values().update(
+                spreadsheetId=self.sheet_id,
+                range=range_name,
+                valueInputOption='RAW',
+                body=body
+            ).execute()
+
+    def _get_next_row(self):
+        """
+        Find the next empty row number to write data to.
+
+        Scans column A to find the last row with data and returns the next row number.
+        This ensures new data is appended without overwriting existing content.
+
+        Returns:
+            int: The row number (1-indexed) where the next data should be written.
+                 Returns 2 if unable to determine (assumes row 1 has headers).
+        """
+        try:
+            # Get all data to find the last row with content
+            range_name = f"{self.worksheet_name}!A:A"
+            result = self.service.spreadsheets().values().get(
+                spreadsheetId=self.sheet_id,
+                range=range_name
+            ).execute()
+
+            values = result.get('values', [])
+            return len(values) + 1  # Next row after the last one with data
+
+        except Exception:
+            return 2  # Start at row 2 (after headers) if we can't determine
+
+    def _normalize_record(self, record):
+        """
+        Convert a record (dict or DASRecord) to a standardized dictionary format.
+
+        Args:
+            record: Either a dictionary or a DASRecord object
+
+        Returns:
+            dict: Standardized dictionary with timestamp and other fields
+        """
+        if isinstance(record, DASRecord):
+            result_dict = record.fields.copy()
+            result_dict['timestamp'] = record.timestamp
+            return result_dict
+        elif isinstance(record, dict):
+            # It's already a dictionary
+            return record.copy()
+        else:
+            raise ValueError(f"Unsupported record type: {type(record)}")
+
+    def _ensure_timestamp_first(self, keys):
+        """
+        Ensure 'timestamp' is the first column, followed by other keys in order.
+
+        Args:
+            keys: Iterable of column names
+
+        Returns:
+            list: Ordered list with 'timestamp' first, then other keys
+        """
+        keys_list = list(keys)
+        ordered_keys = []
+
+        # Always put timestamp first if it exists
+        if 'timestamp' in keys_list:
+            ordered_keys.append('timestamp')
+            keys_list.remove('timestamp')
+
+        # Add remaining keys in order they appear
+        ordered_keys.extend(keys_list)
+
+        return ordered_keys
+
+    def _format_value_for_sheets(self, value):
+        """
+        Format a value appropriately for Google Sheets while preserving numeric types.
+
+        Args:
+            value: The value to format
+
+        Returns:
+            The value formatted for Google Sheets:
+            - Numbers (int, float) are returned as-is to preserve numeric type
+            - None values are converted to empty string
+            - Booleans are converted to strings to avoid confusion
+            - Everything else is converted to string
+        """
+        if value is None:
+            return ''
+        elif isinstance(value, bool):
+            # Convert booleans to strings to avoid confusion with 1/0
+            return str(value)
+        elif isinstance(value, (int, float)):
+            # Preserve numeric types - don't convert to string
+            return value
+        else:
+            # Convert everything else to string
+            return str(value)
+
+    def write_dict(self, record_dict):
+        """
+        Legacy method: Write a single dictionary as a new row.
+
+        This method is maintained for backward compatibility.
+        Use write() instead for new code.
+
+        Args:
+            record_dict (dict): Dictionary to write as a row
+
+        Returns:
+            dict: Response from the Google Sheets API update operation
+        """
+        return self.write(record_dict)
+
+    def write_dicts(self, record_dicts):
+        """
+        Legacy method: Write multiple dictionaries as rows.
+
+        This method is maintained for backward compatibility.
+        Use write() instead for new code.
+
+        Args:
+            record_dicts (list): List of dictionaries to write as rows
+
+        Returns:
+            dict: Response from the Google Sheets API update operation
+        """
+        return self.write(record_dicts)
+
+    def write(self, records):
+        """
+        Write record(s) to the Google Sheet with automatic timestamp column management.
+
+        Accepts either a single record or a list of records. Each record can be either
+        a dictionary or a DASRecord object. The 'timestamp' field is always placed in
+        the first column. For DASRecord objects, the record's timestamp attribute is
+        automatically used. Numeric values are preserved as numbers in the spreadsheet.
+
+        Args:
+            records: Single record (dict or DASRecord) or list of records to write.
+                    Each record becomes one row, with keys/fields as column headers.
+
+        Returns:
+            dict: Response from the Google Sheets API update operation, or None if
+                  records is empty
+
+        Raises:
+            Exception: If unable to write to the spreadsheet
+            ValueError: If record type is not supported
+
+        Examples:
+            # Write single dictionary with numeric values preserved
+            writer.write({'timestamp': 1234567890, 'name': 'John', 'age': 30, 'salary': 75000.50})
+
+            # Write single DASRecord
+            das_record = DASRecord(timestamp=1234567890, fields={'name': 'Jane', 'age': 25, 'rating': 4.8})
+            writer.write(das_record)
+
+            # Write multiple records (mixed types)
+            records = [
+                {'timestamp': 1234567890, 'name': 'Bob', 'city': 'NYC', 'salary': 75000},
+                DASRecord(timestamp=1234567891, fields={'name': 'Alice',
+                                                        'department': 'Engineering', 'score': 95.5})
+            ]
+            writer.write(records)
+
+            # Timestamp column is always first, other columns follow in order encountered
+            # Numeric values (int, float) are written as numbers, not text
+        """
+        if not records:
+            return None
+
+        # Normalize input to list of records
+        if not isinstance(records, list):
+            records = [records]
+
+        try:
+            # Convert all records to dictionaries
+            normalized_records = []
+            all_keys = set()
+
+            for record in records:
+                normalized = self._normalize_record(record)
+                normalized_records.append(normalized)
+                all_keys.update(normalized.keys())
+
+            # Ensure timestamp is first in the column order
+            ordered_keys = self._ensure_timestamp_first(all_keys)
+
+            # Update headers with any new keys (maintaining timestamp-first order)
+            new_headers = []
+            for key in ordered_keys:
+                if key not in self.headers:
+                    new_headers.append(key)
+
+            if new_headers:
+                # Insert new headers in the correct position
+                if 'timestamp' in new_headers and 'timestamp' not in self.headers:
+                    # If timestamp is new, it goes first
+                    self.headers.insert(0, 'timestamp')
+                    new_headers.remove('timestamp')
+
+                # Add remaining new headers to the end
+                self.headers.extend(new_headers)
+
+                # Update the header row in the sheet
+                range_name = f"{self.worksheet_name}!1:1"
+                body = {'values': [self.headers]}
+
+                self.service.spreadsheets().values().update(
+                    spreadsheetId=self.sheet_id,
+                    range=range_name,
+                    valueInputOption='RAW',
+                    body=body
+                ).execute()
+
+            # Create rows data with proper value formatting
+            rows_data = []
+            for record_dict in normalized_records:
+                row_data = []
+                for header in self.headers:
+                    value = record_dict.get(header)
+                    formatted_value = self._format_value_for_sheets(value)
+                    row_data.append(formatted_value)
+                rows_data.append(row_data)
+
+            # Find next available row
+            next_row = self._get_next_row()
+
+            if len(rows_data) == 1:
+                # Single row
+                range_name = f"{self.worksheet_name}!A{next_row}:{chr(65 + len(self.headers) - 1)}{next_row}"  # noqa E501
+            else:
+                # Multiple rows
+                end_row = next_row + len(rows_data) - 1
+                range_name = f"{self.worksheet_name}!A{next_row}:{chr(65 + len(self.headers) - 1)}{end_row}"  # noqa E501
+
+            # Write the data using USER_ENTERED to allow Sheets to interpret numeric values
+            body = {'values': rows_data}
+
+            result = self.service.spreadsheets().values().update(
+                spreadsheetId=self.sheet_id,
+                range=range_name,
+                valueInputOption='USER_ENTERED',  # Changed from 'RAW' to preserve numeric types
+                body=body
+            ).execute()
+
+            return result
+
+        except Exception as e:
+            raise Exception(f"Failed to write to spreadsheet: {str(e)}")
+
+    def get_headers(self):
+        """
+        Return the current column headers in the sheet.
+
+        Returns:
+            list: A copy of the current column headers list. Modifications to this
+                  list won't affect the internal headers.
+
+        Example:
+            headers = writer.get_headers()
+            print(f"Current columns: {headers}")
+            # Output: Current columns: ['timestamp', 'name', 'age', 'city', 'email']
+        """
+        return self.headers.copy()
+
+    def clear_sheet(self):
+        """
+        Clear all data from the worksheet.
+
+        Removes all content from the specified worksheet, including headers and data.
+        Resets the internal headers list to empty.
+
+        Raises:
+            Exception: If unable to clear the sheet
+
+        Warning:
+            This operation cannot be undone. All data in the worksheet will be lost.
+
+        Example:
+            writer.clear_sheet()  # Removes all data from the worksheet
+        """
+        try:
+            range_name = f"{self.worksheet_name}!A:Z"
+            self.service.spreadsheets().values().clear(
+                spreadsheetId=self.sheet_id,
+                range=range_name
+            ).execute()
+            self.headers = []
+        except Exception as e:
+            raise Exception(f"Failed to clear sheet: {str(e)}")
+
+
+# Example usage:
+if __name__ == "__main__":
+    # Initialize the writer
+    writer = GoogleSheetsWriter(
+        sheet_name_or_id="sheet_id_here",
+        auth_key_path="path_to_auth_key_here.json",
+        use_service_account=True,
+        worksheet_name="Sheet1"
+    )
+
+    # Write single dictionary with numeric values
+    record1 = {
+        'timestamp': 1234567890,
+        'name': 'John Doe',
+        'age': 30,
+        'city': 'New York',
+        'salary': 75000.50,
+        'rating': 4.8
+    }
+    writer.write(record1)
+
+    # Write another dict with new columns including numeric ones
+    record2 = {
+        'timestamp': 1234567891,
+        'name': 'Jane Smith',
+        'age': 25,
+        'city': 'Los Angeles',
+        'occupation': 'Engineer',
+        'salary': 85000,
+        'bonus': 10000.25
+    }
+    writer.write(record2)
+
+    # Write multiple dictionaries at once with mixed numeric types
+    records = [
+        {'timestamp': 1234567892, 'name': 'Bob', 'age': 35, 'city': 'Chicago', 'salary': 75000, 'score': 89.5},
+        {'timestamp': 1234567893, 'name': 'Alice', 'age': 28, 'occupation': 'Designer', 'salary': 65000, 'score': 92.1}
+    ]
+    writer.write(records)
+
+    # Write a DASRecord with numeric fields
+    record = DASRecord(
+        timestamp=1234567894,
+        fields={'name': 'Hal', 'favorite_color': 'green', 'years_experience': 5, 'rating': 4.2}
+    )
+    writer.write(record)
+
+    # Check current headers
+    print("Current headers:", writer.get_headers())

--- a/test/logger/writers/test_google_sheets_writer.py
+++ b/test/logger/writers/test_google_sheets_writer.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+
+import unittest
+import logging
+from unittest.mock import Mock, patch
+import sys
+
+# Add the parent directory to sys.path to import the GoogleSheetsWriter
+sys.path.append('.')
+from logger.writers.google_sheets_writer import GoogleSheetsWriter  # noqa: E402
+from logger.utils.das_record import DASRecord  # noqa: E402
+
+
+class TestGoogleSheetsWriter(unittest.TestCase):
+    """Test cases for GoogleSheetsWriter class."""
+
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        # Mock the Google API service
+        self.mock_service = Mock()
+        self.mock_spreadsheets = Mock()
+        self.mock_values = Mock()
+
+        # Set up the mock chain
+        self.mock_service.spreadsheets.return_value = self.mock_spreadsheets
+        self.mock_spreadsheets.values.return_value = self.mock_values
+
+        # Mock the get, update, clear, and batchUpdate methods
+        self.mock_get = Mock()
+        self.mock_update = Mock()
+        self.mock_clear = Mock()
+        self.mock_batch_update = Mock()
+
+        self.mock_values.get.return_value = self.mock_get
+        self.mock_values.update.return_value = self.mock_update
+        self.mock_values.clear.return_value = self.mock_clear
+        self.mock_spreadsheets.get.return_value = self.mock_spreadsheets
+        self.mock_spreadsheets.batchUpdate.return_value = self.mock_batch_update
+
+        # Default return values
+        self.mock_get.execute.return_value = {'values': []}
+        self.mock_update.execute.return_value = {'updatedRows': 1}
+        self.mock_clear.execute.return_value = {}
+        self.mock_batch_update.execute.return_value = {}
+
+        # Mock spreadsheet metadata for _ensure_worksheet_exists
+        mock_spreadsheet_data = {
+            'sheets': [
+                {'properties': {'title': 'TestSheet'}},
+                {'properties': {'title': 'Sheet1'}}
+            ]
+        }
+        self.mock_spreadsheets.execute.return_value = mock_spreadsheet_data
+
+        # Patch the authentication and service creation
+        self.credentials_patcher = \
+            patch('logger.writers.google_sheets_writer.Credentials.from_service_account_file')
+        self.build_patcher = patch('logger.writers.google_sheets_writer.build')
+
+        self.mock_credentials = self.credentials_patcher.start()
+        self.mock_build = self.build_patcher.start()
+
+        self.mock_build.return_value = self.mock_service
+
+        # Create writer instance
+        self.writer = GoogleSheetsWriter(
+            sheet_name_or_id="test_sheet_id",
+            auth_key_path="fake_key.json",
+            use_service_account=True,
+            worksheet_name="TestSheet"
+        )
+
+    def tearDown(self):
+        """Clean up after each test method."""
+        if hasattr(self, 'credentials_patcher'):
+            self.credentials_patcher.stop()
+        if hasattr(self, 'build_patcher'):
+            self.build_patcher.stop()
+
+    def test_initialization(self):
+        """Test GoogleSheetsWriter initialization."""
+        self.assertEqual(self.writer.sheet_id, "test_sheet_id")
+        self.assertEqual(self.writer.worksheet_name, "TestSheet")
+        self.assertEqual(self.writer.headers, [])
+        self.assertIsNotNone(self.writer.service)
+
+    def test_get_sheet_id_from_url(self):
+        """Test extracting sheet ID from Google Sheets URL."""
+        url = "https://docs.google.com/spreadsheets/d/1ABC123def456/edit#gid=0"
+
+        with patch('logger.writers.google_sheets_writer.Credentials.from_service_account_file'), \
+                patch('logger.writers.google_sheets_writer.build'):
+            # Mock the service for URL test
+            mock_service_url = Mock()
+            mock_spreadsheets_url = Mock()
+            mock_service_url.spreadsheets.return_value = mock_spreadsheets_url
+            mock_spreadsheets_url.get.return_value.execute.return_value = {
+                'sheets': [{'properties': {'title': 'Sheet1'}}]
+            }
+            mock_spreadsheets_url.values.return_value.get.return_value.execute.return_value = {'values': []}
+
+            with patch('logger.writers.google_sheets_writer.build', return_value=mock_service_url):
+                writer = GoogleSheetsWriter(
+                    sheet_name_or_id=url,
+                    auth_key_path="fake_key.json"
+                )
+                self.assertEqual(writer.sheet_id, "1ABC123def456")
+
+    def test_load_existing_headers(self):
+        """Test loading existing headers from sheet."""
+        # Mock existing headers
+        mock_service_headers = Mock()
+        mock_spreadsheets_headers = Mock()
+        mock_values_headers = Mock()
+
+        mock_service_headers.spreadsheets.return_value = mock_spreadsheets_headers
+        mock_spreadsheets_headers.values.return_value = mock_values_headers
+        mock_spreadsheets_headers.get.return_value.execute.return_value = {
+            'sheets': [{'properties': {'title': 'MyData'}}]
+        }
+        mock_values_headers.get.return_value.execute.return_value = {
+            'values': [['timestamp', 'name', 'age', 'city']]
+        }
+
+        # Create new writer to trigger header loading
+        with patch('logger.writers.google_sheets_writer.Credentials.from_service_account_file'), \
+                patch('logger.writers.google_sheets_writer.build', return_value=mock_service_headers):
+            writer = GoogleSheetsWriter(
+                sheet_name_or_id="test_sheet",
+                auth_key_path="fake_key.json",
+                worksheet_name="MyData"
+            )
+
+            self.assertEqual(writer.headers, ['timestamp', 'name', 'age', 'city'])
+
+    def test_normalize_record_dict(self):
+        """Test normalizing dictionary records."""
+        record = {'name': 'John', 'age': 30, 'timestamp': 1234567890}
+        normalized = self.writer._normalize_record(record)
+
+        self.assertEqual(normalized, record)
+        self.assertIsNot(normalized, record)  # Should be a copy
+
+    def test_normalize_record_das_record(self):
+        """Test normalizing DASRecord objects."""
+        das_record = DASRecord(
+            timestamp=1234567890,
+            fields={'name': 'Jane', 'age': 25}
+        )
+
+        normalized = self.writer._normalize_record(das_record)
+        expected = {'name': 'Jane', 'age': 25, 'timestamp': 1234567890}
+
+        self.assertEqual(normalized, expected)
+
+    def test_normalize_record_invalid_type(self):
+        """Test error handling for invalid record types."""
+        with self.assertRaises(ValueError):
+            self.writer._normalize_record("invalid_record")
+
+    def test_ensure_timestamp_first(self):
+        """Test timestamp column ordering."""
+        keys = ['name', 'age', 'timestamp', 'city']
+        ordered = self.writer._ensure_timestamp_first(keys)
+
+        self.assertEqual(ordered[0], 'timestamp')
+        self.assertEqual(set(ordered), set(keys))
+
+    def test_ensure_timestamp_first_no_timestamp(self):
+        """Test column ordering when no timestamp present."""
+        keys = ['name', 'age', 'city']
+        ordered = self.writer._ensure_timestamp_first(keys)
+
+        self.assertEqual(ordered, ['name', 'age', 'city'])
+
+    def test_format_value_for_sheets_numeric(self):
+        """Test formatting numeric values for sheets."""
+        # Test integer
+        self.assertEqual(self.writer._format_value_for_sheets(42), 42)
+
+        # Test float
+        self.assertEqual(self.writer._format_value_for_sheets(3.14), 3.14)
+
+        # Test None
+        self.assertEqual(self.writer._format_value_for_sheets(None), '')
+
+        # Test string
+        self.assertEqual(self.writer._format_value_for_sheets('hello'), 'hello')
+
+        # Test boolean
+        self.assertEqual(self.writer._format_value_for_sheets(True), 'True')
+
+    def test_get_next_row_empty_sheet(self):
+        """Test getting next row on empty sheet."""
+        self.mock_get.execute.return_value = {'values': []}
+        next_row = self.writer._get_next_row()
+        self.assertEqual(next_row, 1)
+
+    def test_get_next_row_with_data(self):
+        """Test getting next row with existing data."""
+        self.mock_get.execute.return_value = {
+            'values': [['header1'], ['row1'], ['row2'], ['row3']]
+        }
+        next_row = self.writer._get_next_row()
+        self.assertEqual(next_row, 5)  # Next row after 4 existing rows
+
+    def test_write_single_dict(self):
+        """Test writing a single dictionary."""
+        record = {'timestamp': 1234567890, 'name': 'John', 'age': 30}
+
+        # Mock empty sheet initially
+        self.mock_get.execute.return_value = {'values': []}
+
+        self.writer.write(record)
+
+        # Verify update was called
+        self.mock_update.execute.assert_called()
+
+        # Check that headers were updated correctly
+        update_calls = self.mock_update.execute.call_args_list
+
+        # Should have been called twice: once for headers, once for data
+        self.assertEqual(len(update_calls), 2)
+
+    def test_write_single_dict_with_numeric_values(self):
+        """Test writing a single dictionary with numeric values preserved."""
+        record = {'timestamp': 1234567890, 'name': 'John', 'age': 30, 'salary': 75000.50}
+
+        # Mock empty sheet initially
+        self.mock_get.execute.return_value = {'values': []}
+
+        self.writer.write(record)
+
+        # Verify update was called
+        self.mock_update.execute.assert_called()
+
+        # Verify that the last call used USER_ENTERED for value input option
+        # (This ensures numeric values are preserved)
+        last_call_args = self.mock_update.call_args
+        # The update method should have been called with valueInputOption='USER_ENTERED'
+        self.assertTrue(self.mock_update.execute.called)
+
+    def test_write_single_das_record(self):
+        """Test writing a single DASRecord."""
+        das_record = DASRecord(
+            timestamp=1234567890,
+            fields={'name': 'Jane', 'age': 25}
+        )
+
+        self.mock_get.execute.return_value = {'values': []}
+
+        self.writer.write(das_record)
+
+        self.mock_update.execute.assert_called()
+
+    def test_write_multiple_records(self):
+        """Test writing multiple records."""
+        records = [
+            {'timestamp': 1234567890, 'name': 'John', 'age': 30},
+            DASRecord(timestamp=1234567891, fields={'name': 'Jane', 'city': 'NYC'}),
+            {'name': 'Bob', 'department': 'Engineering'}
+        ]
+
+        self.mock_get.execute.return_value = {'values': []}
+
+        self.writer.write(records)
+
+        self.mock_update.execute.assert_called()
+
+        # Verify headers include all fields with timestamp first
+        expected_headers = ['timestamp', 'name', 'age', 'city', 'department']
+        self.assertEqual(set(self.writer.headers), set(expected_headers))
+        self.assertEqual(self.writer.headers[0], 'timestamp')
+
+    def test_write_empty_records(self):
+        """Test writing empty records list."""
+        result = self.writer.write([])
+        self.assertIsNone(result)
+
+        result = self.writer.write(None)
+        self.assertIsNone(result)
+
+    def test_write_with_existing_headers(self):
+        """Test writing when sheet already has headers."""
+        # Set up existing headers
+        self.writer.headers = ['timestamp', 'name', 'age']
+
+        # Mock sheet with existing data
+        self.mock_get.execute.return_value = {
+            'values': [['timestamp', 'name', 'age'], ['123', 'John', '30']]
+        }
+
+        # Write record with new field
+        record = {'timestamp': 1234567892, 'name': 'Jane', 'city': 'NYC'}
+
+        self.writer.write(record)
+
+        # Should update headers to include 'city'
+        self.assertIn('city', self.writer.headers)
+        self.mock_update.execute.assert_called()
+
+    def test_write_dict_legacy_method(self):
+        """Test legacy write_dict method."""
+        record = {'timestamp': 1234567890, 'name': 'John'}
+
+        self.mock_get.execute.return_value = {'values': []}
+
+        # Check if the method exists, skip test if not
+        if not hasattr(self.writer, 'write_dict'):
+            self.skipTest("write_dict method not implemented")
+
+        self.writer.write_dict(record)
+
+        self.mock_update.execute.assert_called()
+
+    def test_write_dicts_legacy_method(self):
+        """Test legacy write_dicts method."""
+        records = [
+            {'timestamp': 1234567890, 'name': 'John'},
+            {'timestamp': 1234567891, 'name': 'Jane'}
+        ]
+
+        self.mock_get.execute.return_value = {'values': []}
+
+        # Check if the method exists, skip test if not
+        if not hasattr(self.writer, 'write_dicts'):
+            self.skipTest("write_dicts method not implemented")
+
+        self.writer.write_dicts(records)
+
+        self.mock_update.execute.assert_called()
+
+    def test_get_headers(self):
+        """Test getting current headers."""
+        self.writer.headers = ['timestamp', 'name', 'age']
+        headers = self.writer.get_headers()
+
+        self.assertEqual(headers, ['timestamp', 'name', 'age'])
+
+        # Verify it's a copy
+        headers.append('new_field')
+        self.assertEqual(self.writer.headers, ['timestamp', 'name', 'age'])
+
+    def test_clear_sheet(self):
+        """Test clearing sheet data."""
+        self.writer.headers = ['timestamp', 'name', 'age']
+
+        self.writer.clear_sheet()
+
+        self.mock_clear.execute.assert_called()
+        self.assertEqual(self.writer.headers, [])
+
+    def test_write_error_handling(self):
+        """Test error handling during write operations."""
+        # Mock an exception during update
+        self.mock_update.execute.side_effect = Exception("API Error")
+
+        record = {'timestamp': 1234567890, 'name': 'John'}
+
+        with self.assertRaises(Exception) as context:
+            self.writer.write(record)
+
+        self.assertIn("Failed to write to spreadsheet", str(context.exception))
+
+    def test_oauth_authentication(self):
+        """Test OAuth authentication path."""
+        patch_str = 'logger.writers.google_sheets_writer.UserCredentials.from_authorized_user_file'
+        with patch(patch_str) as mock_oauth, \
+                patch('logger.writers.google_sheets_writer.build') as mock_build_oauth, \
+                patch('os.path.exists', return_value=True):
+            # Mock valid OAuth credentials
+            mock_creds = Mock()
+            mock_creds.valid = True
+            mock_oauth.return_value = mock_creds
+
+            # Mock the service for OAuth test
+            mock_service_oauth = Mock()
+            mock_spreadsheets_oauth = Mock()
+            mock_service_oauth.spreadsheets.return_value = mock_spreadsheets_oauth
+            mock_spreadsheets_oauth.get.return_value.execute.return_value = {
+                'sheets': [{'properties': {'title': 'Sheet1'}}]
+            }
+            mock_spreadsheets_oauth.values.return_value.get.return_value.execute.return_value = {'values': []}
+            mock_build_oauth.return_value = mock_service_oauth
+
+            writer = GoogleSheetsWriter(
+                sheet_name_or_id="test_sheet",
+                auth_key_path="token.json",
+                use_service_account=False
+            )
+
+            self.assertIsNotNone(writer.service)
+            mock_oauth.assert_called_once()
+
+    def test_range_calculation_single_row(self):
+        """Test range calculation for single row writes."""
+        # Set existing headers to avoid header update calls
+        self.writer.headers = ['timestamp', 'name', 'age']
+
+        # Mock that sheet already has headers so no header update is needed
+        self.mock_get.execute.return_value = {
+            'values': [['timestamp', 'name', 'age'], ['existing', 'data', 'here']]
+        }
+
+        # Mock next row as 5
+        with patch.object(self.writer, '_get_next_row', return_value=5):
+            record = {'timestamp': 123, 'name': 'John', 'age': 30}
+            result = self.writer.write(record)
+
+            # Check that update was called at least once
+            self.assertTrue(self.mock_update.execute.called)
+
+            # Verify the method completed successfully
+            self.assertIsNotNone(result)
+
+    def test_range_calculation_multiple_rows(self):
+        """Test range calculation for multiple row writes."""
+        # Set existing headers to avoid header update calls
+        self.writer.headers = ['timestamp', 'name']
+
+        # Mock that sheet already has headers
+        self.mock_get.execute.return_value = {
+            'values': [['timestamp', 'name'], ['existing', 'data']]
+        }
+
+        with patch.object(self.writer, '_get_next_row', return_value=3):
+            records = [
+                {'timestamp': 123, 'name': 'John'},
+                {'timestamp': 124, 'name': 'Jane'}
+            ]
+            result = self.writer.write(records)
+
+            # Check that update was called at least once
+            self.assertTrue(self.mock_update.execute.called)
+
+            # Verify the method completed successfully
+            self.assertIsNotNone(result)
+
+    def test_ensure_worksheet_exists_force_create(self):
+        """Test creating worksheet when force_create is True."""
+        # Mock a spreadsheet without the target worksheet
+        mock_service_create = Mock()
+        mock_spreadsheets_create = Mock()
+        mock_service_create.spreadsheets.return_value = mock_spreadsheets_create
+
+        # First call: spreadsheet.get() returns sheets without our target
+        mock_spreadsheets_create.get.return_value.execute.return_value = {
+            'sheets': [{'properties': {'title': 'Sheet1'}}]  # Missing 'NewSheet'
+        }
+
+        # Second call: batchUpdate for creating the sheet
+        mock_spreadsheets_create.batchUpdate.return_value.execute.return_value = {}
+
+        # Third call: values().get() for loading headers
+        mock_spreadsheets_create.values.return_value.get.return_value.execute.return_value = {'values': []}
+
+        with patch('logger.writers.google_sheets_writer.Credentials.from_service_account_file'), \
+                patch('logger.writers.google_sheets_writer.build', return_value=mock_service_create):
+            writer = GoogleSheetsWriter(
+                sheet_name_or_id="test_sheet",
+                auth_key_path="fake_key.json",
+                worksheet_name="NewSheet",
+                force_create=True
+            )
+
+            # Verify the worksheet was attempted to be created
+            mock_spreadsheets_create.batchUpdate.assert_called_once()
+            self.assertEqual(writer.worksheet_name, "NewSheet")
+
+    def test_ensure_worksheet_exists_no_force_create(self):
+        """Test error when worksheet doesn't exist and force_create is False."""
+        # Mock a spreadsheet without the target worksheet
+        mock_service_no_create = Mock()
+        mock_spreadsheets_no_create = Mock()
+        mock_service_no_create.spreadsheets.return_value = mock_spreadsheets_no_create
+
+        mock_spreadsheets_no_create.get.return_value.execute.return_value = {
+            'sheets': [{'properties': {'title': 'Sheet1'}}]  # Missing 'NonExistentSheet'
+        }
+
+        with patch('logger.writers.google_sheets_writer.Credentials.from_service_account_file'), \
+                patch('logger.writers.google_sheets_writer.build', return_value=mock_service_no_create):
+            with self.assertRaises(Exception) as context:
+                GoogleSheetsWriter(
+                    sheet_name_or_id="test_sheet",
+                    auth_key_path="fake_key.json",
+                    worksheet_name="NonExistentSheet",
+                    force_create=False
+                )
+
+            self.assertIn("does not exist in spreadsheet", str(context.exception))
+            self.assertIn("force_create=True", str(context.exception))
+
+
+################################################################################
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbosity', dest='verbosity',
+                        default=0, action='count',
+                        help='Increase output verbosity')
+    args = parser.parse_args()
+
+    LOGGING_FORMAT = '%(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(format=LOGGING_FORMAT)
+
+    LOG_LEVELS = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    args.verbosity = min(args.verbosity, max(LOG_LEVELS))
+    logging.getLogger().setLevel(LOG_LEVELS[args.verbosity])
+
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
* First pass at #457: GoogleSheetsWriter

* resolves #457

* Write numeric values to sheet as numbers, rather than text

* Merge dev into master for new master release (#465)

* Issue 416 (#418)

* WIP - initial import, still need to test

* WIP - slight refactor to add filtering

* added requested functionality from issue #416

* code cleanup, expanded documentation

* updated inline documentation

* Flake8 related changes

* Get CDS to actually use standard logging format (#419)

* Issue 422 (#424)

* #423

* #422 - first pass at recursive include-and-merge

* #422 - updated unittest for read_config

* #422 - allow wildcards in includes

* Improve error logging, add temp diagnostics for #422

* #422 - use project base dir as default

* #422 allow using 'include_base_dir' key

* #422 - Add expand_cruise_definition Allows logger config definitions to be placed under the logger definition instead of simply declared there, and fully defined in a later 'configs' section. Does this by reorganizing the 'unexpanded' cruise definition to have the config definitions where expected.

* #422 - Add inference of 'default' mode if no modes are defined

* #422 - Update apis and logger_manager to try to expand logger definitions.

* #422 - add logger template interpolation to expand_cruise_definition()

* #422 - incorporate template expansion into cruise load process

* #422 - clean up test directory with data subdir

* #422 - clean up test directory with data subdir

* #422 - fix unittest

* #422 - check for unexpanded variables and warn if found.

* #422 - Templatize true_winds logger

* #422 - fix so variable substitution also applies to dict keys

* #422 - add template expansion into various loading pathways.

* #422 use YAML variables to shrink modes section

* #422 - alter parser template to also output UDP; allow implicit conversion from DASRecord to JSON str

* Allow ToDASRecordTransform to accept JSON

* Allow TextFileWriter and UDPWriter to take DASRecords Serialize them to JSON before writing.

* Allow CachedDataReader to take list instead of dict of subscription fields e.g.:subscription = {'fields':['S330CourseTrue', 'S330HeadingTrue']}

This makes it easier to write logger templates that use the CachedDataReader

* Modify interpolation transform to accommodate templating

               To simplify templating, can also accept a spec of the form
               of a list:

               [
                 { sources: [MwxAirTemp, RTMPTemp, ...],
                   algorithm: boxcar_average,
                   window: 10,
                   result_prefix: Avg
                 },
                 { sources: [PortTrueWindDir, StbdTrueWindDir],
                   algorithm: polar_average,
                   window: 10,
                   result_prefix: Avg
                 }
               ]

* Minor formatting fix

* #422 - Condense and simplify stock logger templates

* #422 - add missing snapshot data id

* #422 - add missing snapshot data id

* #422 - handle mixed config/templates and apply variable substitution to both

* #422 - add back missing data_id for snapshot and true winds

* #422 - flake8 cleanup

* #422 - rename sample NBP cruises

* #422 - allow modes to be lists, rather than dicts, of configs

* #422 - if no default_mode, assign as first mode in dict

* #422 - allow listen.py to expand configs when passed via --config_file arg

* #422 - shuffle test file names

* Remove stray pprint

* Issue 422 (#426)

* #423

* #422 - first pass at recursive include-and-merge

* #422 - updated unittest for read_config

* #422 - allow wildcards in includes

* Improve error logging, add temp diagnostics for #422

* #422 - use project base dir as default

* #422 allow using 'include_base_dir' key

* #422 - Add expand_cruise_definition Allows logger config definitions to be placed under the logger definition instead of simply declared there, and fully defined in a later 'configs' section. Does this by reorganizing the 'unexpanded' cruise definition to have the config definitions where expected.

* #422 - Add inference of 'default' mode if no modes are defined

* #422 - Update apis and logger_manager to try to expand logger definitions.

* #422 - add logger template interpolation to expand_cruise_definition()

* #422 - incorporate template expansion into cruise load process

* #422 - clean up test directory with data subdir

* #422 - clean up test directory with data subdir

* #422 - fix unittest

* #422 - check for unexpanded variables and warn if found.

* #422 - Templatize true_winds logger

* #422 - fix so variable substitution also applies to dict keys

* #422 - add template expansion into various loading pathways.

* #422 use YAML variables to shrink modes section

* #422 - alter parser template to also output UDP; allow implicit conversion from DASRecord to JSON str

* Allow ToDASRecordTransform to accept JSON

* Allow TextFileWriter and UDPWriter to take DASRecords Serialize them to JSON before writing.

* Allow CachedDataReader to take list instead of dict of subscription fields e.g.:subscription = {'fields':['S330CourseTrue', 'S330HeadingTrue']}

This makes it easier to write logger templates that use the CachedDataReader

* Modify interpolation transform to accommodate templating

               To simplify templating, can also accept a spec of the form
               of a list:

               [
                 { sources: [MwxAirTemp, RTMPTemp, ...],
                   algorithm: boxcar_average,
                   window: 10,
                   result_prefix: Avg
                 },
                 { sources: [PortTrueWindDir, StbdTrueWindDir],
                   algorithm: polar_average,
                   window: 10,
                   result_prefix: Avg
                 }
               ]

* Minor formatting fix

* #422 - Condense and simplify stock logger templates

* #422 - add missing snapshot data id

* #422 - add missing snapshot data id

* #422 - handle mixed config/templates and apply variable substitution to both

* #422 - add back missing data_id for snapshot and true winds

* #422 - flake8 cleanup

* #422 - rename sample NBP cruises

* #422 - allow modes to be lists, rather than dicts, of configs

* #422 - if no default_mode, assign as first mode in dict

* #422 - allow listen.py to expand configs when passed via --config_file arg

* #422 - shuffle test file names

* Remove stray pprint

* #422 - add expand_cruise_definition to listen.py init

* Issue 427 (#428)

* #427 - first pass at fixing #427.

* #427 - first pass at fixing #427.

* Remove extraneous comment

* Resolves #429 - adds time_acceleration_factor to LogfileReader (#430)

* Disable test of MQTTReader, which isn't really debugged

* Disable test_mqtt_reader.py

* Resolves #434 (#435)

* Next pass at #427.

* #427 - add unittest

* #427 flake8

* #427 fix comments

* Issue 427 (#436)

* Next pass at #427.

* #427 - add unittest

* #427 flake8

* #427 fix comments

* Issue 431 - move system-provided device type and logger templates definitions from local/ -> contrib/ (#433)

* #431 - move device and logger_template files, add backward compatibility symlinks

* #431 - update references from local/ to contrib/

* #431 - update html doc references from local/ to contrib/

* #431 - remove stray old doc

* Fix listen.py from trying to expand simple config.

* Issue 425 (#438)

* Initial pass at #425 using sockets rather than IPC

* #425 - SocketReader returns str by default

* #425 - update autogenerated HTML docs

* #425 - add forgotten html docs

* Issue 422 (#439)

* #423

* #422 - first pass at recursive include-and-merge

* #422 - updated unittest for read_config

* #422 - allow wildcards in includes

* Improve error logging, add temp diagnostics for #422

* #422 - use project base dir as default

* #422 allow using 'include_base_dir' key

* #422 - Add expand_cruise_definition Allows logger config definitions to be placed under the logger definition instead of simply declared there, and fully defined in a later 'configs' section. Does this by reorganizing the 'unexpanded' cruise definition to have the config definitions where expected.

* #422 - Add inference of 'default' mode if no modes are defined

* #422 - Update apis and logger_manager to try to expand logger definitions.

* #422 - add logger template interpolation to expand_cruise_definition()

* #422 - incorporate template expansion into cruise load process

* #422 - clean up test directory with data subdir

* #422 - clean up test directory with data subdir

* #422 - fix unittest

* #422 - check for unexpanded variables and warn if found.

* #422 - Templatize true_winds logger

* #422 - fix so variable substitution also applies to dict keys

* #422 - add template expansion into various loading pathways.

* #422 use YAML variables to shrink modes section

* #422 - alter parser template to also output UDP; allow implicit conversion from DASRecord to JSON str

* Allow ToDASRecordTransform to accept JSON

* Allow TextFileWriter and UDPWriter to take DASRecords Serialize them to JSON before writing.

* Allow CachedDataReader to take list instead of dict of subscription fields e.g.:subscription = {'fields':['S330CourseTrue', 'S330HeadingTrue']}

This makes it easier to write logger templates that use the CachedDataReader

* Modify interpolation transform to accommodate templating

               To simplify templating, can also accept a spec of the form
               of a list:

               [
                 { sources: [MwxAirTemp, RTMPTemp, ...],
                   algorithm: boxcar_average,
                   window: 10,
                   result_prefix: Avg
                 },
                 { sources: [PortTrueWindDir, StbdTrueWindDir],
                   algorithm: polar_average,
                   window: 10,
                   result_prefix: Avg
                 }
               ]

* Minor formatting fix

* #422 - Condense and simplify stock logger templates

* #422 - add missing snapshot data id

* #422 - add missing snapshot data id

* #422 - handle mixed config/templates and apply variable substitution to both

* #422 - add back missing data_id for snapshot and true winds

* #422 - flake8 cleanup

* #422 - rename sample NBP cruises

* #422 - allow modes to be lists, rather than dicts, of configs

* #422 - if no default_mode, assign as first mode in dict

* #422 - allow listen.py to expand configs when passed via --config_file arg

* #422 - shuffle test file names

* Remove stray pprint

* #422 - add expand_cruise_definition to listen.py init

* Tried to add config_templates to read_config but failed (#437)

Best I could do was build the templates and new config files

* #422 #437 - add handling for config_templates.

* #422 - flake8

---------



* Fix default slice separator - should be None

* Add extra AIS NMEA header

* Fix missing data_id in record parser

* Resolves #440

* Resolves #440 (#441)

* Explicitly warn when data_id doesn't match any key in field_patterns dict

* Starting to resolve #442

* #442

* #442 add missing name to parameter

* #442

* #442

* #442, calibration logger template

* Issue 442 (#443)

* Starting to resolve #442

* #442

* #442 add missing name to parameter

* #442

* #442

* #442, calibration logger template

* Fix typo in documentation string

* Resolves #446 - Dynamically build cds-ws URL to account for accessing OpenRVDAS via port forwarding (#447)

* Resolves #446.

* Resolves #446.

* Give test_listener.py an actual type incompatibility to catch.

* Test SocketReader with/without keep_binary=True

* Remove stray merge artifact from calibration template

* Resolves #451 and expands unittest to verify. (#452)

* #454 - added keep_empty_records flag (#456)

* #454 - added keep_empty_records flag

* Change parameter to allow_empty, also add to udp_reader.py

* Issue 459 (#460)

* code changes to implement issue #459

Adds pattern-based suffix/header to log files

Allows to specify suffix, header, and header_file as dictionaries, enabling pattern-based selection based on the log record content. This allows to route records to different files with different headers/suffixes based on regex matching. Also fixes an issue where suffix was not optional.

* streamlined code

* updated docstring

* Improves LogfileWriter error handling and mapping

Adds enhanced error and warning logging for scenarios where suffix, header, or header file mappings fail in LogfileWriter. This includes checks for missing suffixes and more informative warnings for header/header file lookup failures, improving debugging and system stability. Also includes added tests to validate the new error handling.

* Issue 379 (#461)

* Adds Sealog reader

Adds a reader that connects to a Sealog websocket server.

This reader retrieves events from the server and converts them into DASRecord objects for further processing.  It handles reconnection logic and different SSL configurations for secure connections. A sample configuration file is included for testing.

* Adds transform to convert records to Sealog events

Implements a transform that converts DASRecords into Sealog event dictionaries based on a YAML configuration.

The configuration specifies how to map input data fields to Sealog event fields, allowing for flexible event creation. It includes fallback mechanisms for unknown data IDs and supports single records and lists of records.

The transform uses a configuration file to specify:
- `data_id` to determine which set of rules to apply
- `event_value` (optional): default event value for the record.
- `event_author` (optional): author string to include in the event.
- `event_free_text` (optional): free text string for the event.
- `field_map` (optional): mapping of input record field names to event option names.
- `_default` (optional): fallback configuration applied if the record's `data_id` is not found.

* Uses isinstance for type checking

Replaces `type(record) is list` with `isinstance(record, list)` for more robust type checking.

This change ensures that subclasses of `list` are also correctly identified, improving the flexibility and reliability of the code.

* Adds Sealog writer for event submission

Implements a writer class to submit event data to a Sealog Server API.

The writer includes:
- Connectivity testing to the Sealog server.
- Data transformation before submission.
- Error handling for API requests.

* WIP: probably doesn't work

just for review purposes

* WIP: #379, debugging refactor

* WIP: #379, expanding config file functionality

config can now contain additional event options to add to the event.  If the option also exists in the fields then it will be over written by the field value... this basically implements default values

* Adds Sealog control transform

Implements a transform that processes Sealog events and submits set_active_mode commands to OpenRVDAS based on the event's value and options. Also refactors the to_event function in sealog_event.py to handle different types of records and configurations, improving flexibility and error handling during event processing.

* removed sealog.yaml

* flake8 lint'd code

* WIP: #458

First stab at unifying the arguments for FileWriter and LogfileWriter

* Fixed broken logic when calculating default date_format

* Removes deprecated warning, adds test for writing to stdout

* updated date_format validation to account for j-days

* Updated unit tests

* Resolves #463 - try terminating process gently, and escalate if failing. (#464)

---------



---------