### PR TITLE
Issue 507 - unify CSIRO and CORIOLIX regex parse transforms

### DIFF
--- a/logger/transforms/regex_parse_transform.py
+++ b/logger/transforms/regex_parse_transform.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Unified RegexParseTransform.
+
+This class unifies the functionality of RegexTransform and RegexParseTransform
+into a single, robust regex-based transformer.
+
+It uses the pure-regex parsing engine (logger.utils.regex_parser) rather than
+the format-string parser, and allows for optional type conversion of fields.
+"""
+
+import sys
+import json
+from typing import Union, Dict, List
+
+# Adjust paths as per your project structure
+from os.path import dirname, realpath
+
+sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
+
+from logger.utils.das_record import DASRecord  # noqa: E402
+from logger.transforms.transform import Transform  # noqa: E402
+from logger.transforms.convert_fields_transform import ConvertFieldsTransform  # noqa: E402
+
+# Uses the 're' based parser (formerly used by RegexTransform)
+from logger.utils import regex_parser  # noqa: E402
+
+
+class RegexParseTransform(Transform):
+    r"""
+    Parses a string record into a Python dict (or DASRecord/JSON) using
+    regular expressions, with optional field type conversion.
+
+    This implementation uses the 're' module for parsing (via regex_parser)
+    and does NOT depend on ParseTransform.
+
+    **Example Configuration:**
+
+    .. code-block:: yaml
+
+        - class: RegexParseTransform
+          module: logger.transforms.regex_parse_transform
+          kwargs:
+            return_das_record: true
+            data_id: gnsspo112593  # Overrides or fills in data_id
+            field_patterns:
+              GPZDA: '^\WGPZDA,(?P<utc_time>\d+\.\d+),(?P<day>\d{2}),(?P<month>\d{2}),
+                      (?P<year>\d{4}),(?P<tzoffset_hours>\d{0,2}),
+                      (?P<tzoffset_mins>\d{0,2})\*(?P<checksum>[0-9A-F]{2})$'
+              GPGGA: '^\WGPGGA,(?P<utc_position_fix>\d+\.\d+),(?P<latitude>\d+\.\d+),
+                      (?P<latitude_dir>[NS]),(?P<longitude>\d+\.\d+),(?P<longitude_dir>[EW]),
+                      (?P<gps_quality_indicator>\d+),(?P<num_sat_vis>\d+),(?P<hdop>\d+\.\d+),
+                      (?P<ortho_height>\-?\d+\.\d+),M,(?P<geoid_separation>\-?\d+\.\d+),M,
+                      (?P<age>[\d\.]*)?,(\d{4})?\*(?P<checksum>[0-9A-F]{2})$'
+
+            # --- Field Conversion Arguments ---
+            delete_source_fields: true
+            delete_unconverted_fields: true
+            fields:
+              latitude:
+                data_type: float
+              cog_true:
+                data_type: float
+            lat_lon_fields:
+              latitude: [latitude, latitude_dir]
+              longitude: [longitude, longitude_dir]
+    """
+
+    def __init__(self,
+                 # --- Parsing Arguments (RegexParser) ---
+                 record_format: str = None,
+                 field_patterns: Union[List, Dict] = None,
+                 data_id: str = None,
+
+                 # --- Output Format Arguments ---
+                 return_json: bool = False,
+                 return_das_record: bool = False,
+
+                 # --- Type Conversion Arguments (ConvertFieldsTransform) ---
+                 fields: Dict = None,
+                 lat_lon_fields: Dict = None,
+                 delete_source_fields: bool = False,
+                 delete_unconverted_fields: bool = False,
+                 **kwargs):
+        """
+        Args:
+            record_format (str): A regex string to match the record envelope (timestamp, data_id).
+                                 Defaults to regex_parser.DEFAULT_RECORD_FORMAT.
+
+            field_patterns (list/dict):
+                - A list of regex patterns to match the field body.
+                - A dict of {message_type: pattern}.
+
+            data_id (str): If specified, this string is used as the data_id for all records,
+                           overriding any data_id extracted from the source record.
+
+            return_json (bool): Return a JSON string representation of the record.
+
+            return_das_record (bool): Return a DASRecord object (default is dict).
+
+            fields (dict): Mapping of field names to target types (e.g., {'temp': 'float'}).
+                           If provided, ConvertFieldsTransform is instantiated internally.
+
+            lat_lon_fields (dict): Mapping for NMEA lat/lon conversion.
+
+            delete_source_fields (bool): Remove original fields after conversion.
+
+            delete_unconverted_fields (bool): Remove fields that were not converted.
+        """
+        super().__init__(**kwargs)  # processes 'quiet' and type hints
+
+        self.return_json = return_json
+        self.return_das_record = return_das_record
+        # self.quiet = quiet  # is taken care of in BaseModule init from **kwargs
+
+        # 1. Initialize the Parser (RegexParser)
+        # We configure it to return a dict or DASRecord initially so we can process
+        # fields. We handle the final JSON serialization ourselves if requested.
+        use_das_record = True if (return_das_record or fields or lat_lon_fields) else False
+
+        self.parser = regex_parser.RegexParser(
+            record_format=record_format,
+            field_patterns=field_patterns,
+            data_id=data_id,
+            return_json=False,  # Handle JSON manually after conversion
+            return_das_record=use_das_record,
+            quiet=self.quiet
+        )
+
+        # 2. Initialize the Converter (if requested)
+        self.converter = None
+        if (fields or lat_lon_fields) and ConvertFieldsTransform:
+            self.converter = ConvertFieldsTransform(
+                fields=fields,
+                lat_lon_fields=lat_lon_fields,
+                delete_source_fields=delete_source_fields,
+                delete_unconverted_fields=delete_unconverted_fields,
+                quiet=self.quiet
+            )
+
+    def transform(self, record: str) -> Union[Dict, str, DASRecord, List]:
+        """
+        Parse the record, optionally convert fields, and return the result.
+        """
+        # See if it's something we can process, and if not, try digesting
+        if not self.can_process_record(record):  # BaseModule
+            return self.digest_record(record)  # BaseModule
+
+        # 1. Parse
+        # Returns a DASRecord (if we asked for it) or a dict
+        parsed_record = self.parser.parse_record(record)
+
+        if not parsed_record:
+            return None
+
+        # 2. Convert Fields
+        if self.converter:
+            # ConvertFieldsTransform modifies in place or returns a copy
+            parsed_record = self.converter.transform(parsed_record)
+            if not parsed_record:
+                return None
+
+        # 3. Format Output
+        # At this point 'parsed_record' is likely a DASRecord (if we used converter)
+        # or a dict (if we didn't use converter and didn't ask for DASRecord).
+
+        if self.return_json:
+            if isinstance(parsed_record, DASRecord):
+                # Construct dict for serialization
+                rec_dict = {
+                    'data_id': parsed_record.data_id,
+                    'timestamp': parsed_record.timestamp,
+                    'fields': parsed_record.fields
+                }
+                if parsed_record.metadata:
+                    rec_dict['metadata'] = parsed_record.metadata
+                return json.dumps(rec_dict)
+            else:
+                return json.dumps(parsed_record)
+
+        elif self.return_das_record:
+            # User specifically asked for DASRecord
+            if isinstance(parsed_record, dict):
+                # Upgrade dict to DASRecord if parser returned dict
+                return DASRecord(
+                    data_id=parsed_record.get('data_id'),
+                    timestamp=parsed_record.get('timestamp'),
+                    fields=parsed_record.get('fields'),
+                    metadata=parsed_record.get('metadata')
+                )
+            return parsed_record
+
+        else:
+            # User wants a plain dictionary
+            if isinstance(parsed_record, DASRecord):
+                rec_dict = {
+                    'data_id': parsed_record.data_id,
+                    'timestamp': parsed_record.timestamp,
+                    'fields': parsed_record.fields
+                }
+                if parsed_record.metadata:
+                    rec_dict['metadata'] = parsed_record.metadata
+                return rec_dict
+            return parsed_record
+
+
+# Alias for backward compatibility
+RegexTransform = RegexParseTransform

--- a/logger/transforms/regex_parse_transform.py
+++ b/logger/transforms/regex_parse_transform.py
@@ -1,20 +1,15 @@
 #!/usr/bin/env python3
 """
-Unified RegexParseTransform.
+RegexParseTransform - a thin wrapper around RegexParser.
 
-This class unifies the functionality of the CORIOLIX RegexTransform and
-CSIRO's RegexParseTransform into a single, robust regex-based transformer.
+This transform parses text records into DASRecord objects using regular
+expressions. It delegates all parsing, device-aware processing, and metadata
+injection to the underlying RegexParser.
 
-It uses the pure-regex parsing engine (logger.utils.regex_parser) rather than
-the format-string parser, and allows for optional type conversion of fields.
-
-It also allows use of dicts of {message_type: regex} in field_patterns to capture
-message_type, and allows specifying a data_id, either if the data string doesn't
-have one, or to override the one that is there.
+The architecture parallels ParseTransform, which wraps RecordParser.
 """
 
 import sys
-import glob
 from typing import Union, Dict, List
 
 from os.path import dirname, realpath
@@ -23,13 +18,13 @@ sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 
 from logger.utils.das_record import DASRecord  # noqa: E402
 from logger.transforms.transform import Transform  # noqa: E402
-from logger.transforms.convert_fields_transform import ConvertFieldsTransform  # noqa: E402
-
-# Uses the 're' based parser (formerly used by RegexTransform)
 from logger.utils import regex_parser  # noqa: E402
-from logger.utils import read_config  # noqa: E402
 
-DEFAULT_DEFINITION_PATH = 'contrib/devices/*.yaml'
+# Optional: for generic field conversion via 'fields' parameter
+try:
+    from logger.transforms.convert_fields_transform import ConvertFieldsTransform
+except ImportError:
+    ConvertFieldsTransform = None
 
 
 class RegexParseTransform(Transform):
@@ -37,8 +32,8 @@ class RegexParseTransform(Transform):
     Parses a string record into a DASRecord using regular expressions,
     with optional field type conversion.
 
-    This implementation uses the 're' module for parsing (via regex_parser)
-    and does NOT depend on ParseTransform.
+    This is a thin wrapper around RegexParser. All parsing logic, device-aware
+    field processing, and metadata injection are handled by the parser.
 
     **Example Configuration:**
 
@@ -49,107 +44,81 @@ class RegexParseTransform(Transform):
           kwargs:
             data_id: gnsspo112593  # Overrides or fills in data_id
             field_patterns:
-              GPZDA: '^\WGPZDA,(?P<utc_time>\d+\.\d+),(?P<day>\d{2}),(?P<month>\d{2}),
-                      (?P<year>\d{4}),(?P<tzoffset_hours>\d{0,2}),
-                      (?P<tzoffset_mins>\d{0,2})\*(?P<checksum>[0-9A-F]{2})$'
-              GPGGA: '^\WGPGGA,(?P<utc_position_fix>\d+\.\d+),(?P<latitude>\d+\.\d+),
-                      (?P<latitude_dir>[NS]),(?P<longitude>\d+\.\d+),(?P<longitude_dir>[EW]),
-                      (?P<gps_quality_indicator>\d+),(?P<num_sat_vis>\d+),(?P<hdop>\d+\.\d+),
-                      (?P<ortho_height>\-?\d+\.\d+),M,(?P<geoid_separation>\-?\d+\.\d+),M,
-                      (?P<age>[\d\.]*)?,(\d{4})?\*(?P<checksum>[0-9A-F]{2})$'
+              GPZDA: '^\WGPZDA,(?P<utc_time>\d+\.\d+),...'
+              GPGGA: '^\WGPGGA,(?P<utc_position_fix>\d+\.\d+),...'
 
-            # --- Field Conversion Arguments ---
-            delete_source_fields: true
-            delete_unconverted_fields: true
-            fields:
-              latitude:
-                data_type: float
-              cog_true:
-                data_type: float
-            lat_lon_fields:
-              latitude: [latitude, latitude_dir]
-              longitude: [longitude, longitude_dir]
+    Or using device definitions:
+
+    .. code-block:: yaml
+
+        - class: RegexParseTransform
+          module: logger.transforms.regex_parse_transform
+          kwargs:
+            definition_path: 'local/devices/*.yaml'
+            metadata_interval: 60
     """
 
     def __init__(self,
-                 # --- Parsing Arguments (RegexParser) ---
+                 # --- Parsing Arguments (passed to RegexParser) ---
                  record_format: str = None,
                  field_patterns: Union[List, Dict] = None,
                  data_id: str = None,
                  definition_path: str = None,
+                 metadata: Dict = None,
+                 metadata_interval: float = None,
+                 # --- Additional Transform Arguments ---
                  fields: Dict = None,
                  delete_source_fields: bool = False,
                  delete_unconverted_fields: bool = False,
-                 metadata: Dict = None,
-                 metadata_interval: float = None,
                  **kwargs):
         """
         Args:
-            record_format (str): A regex string to match the record envelope (timestamp, data_id).
-                                 Defaults to regex_parser.DEFAULT_RECORD_FORMAT.
+            record_format (str): A regex string to match the record envelope
+                (timestamp, data_id). Defaults to regex_parser.DEFAULT_RECORD_FORMAT.
 
             field_patterns (list/dict):
                 - A list of regex patterns to match the field body.
                 - A dict of {message_type: pattern}.
+                If None, patterns are loaded from definition_path.
 
-            data_id (str): If specified, this string is used as the data_id for all records,
-                           overriding any data_id extracted from the source record.
+            data_id (str): If specified, this string is used as the data_id
+                for all records, overriding any data_id extracted from the
+                source record.
 
-            definition_path (str): Wildcarded path matching YAML definitions for devices.
-                                   Used only if 'field_patterns' is None.
-                                   Defaults to 'contrib/devices/*.yaml'.
+            definition_path (str): Wildcarded path matching YAML definitions
+                for devices. Used only if 'field_patterns' is None.
+                Defaults to regex_parser.DEFAULT_DEFINITION_PATH.
 
-            fields (dict): Mapping of field names to target types (e.g., {'temp': 'float'}).
-                           If provided, ConvertFieldsTransform is instantiated internally.
+            metadata (dict): If field_patterns is not None, the metadata to
+                send along with data records.
+
+            metadata_interval (float): If not None, include the description,
+                units and other metadata pertaining to each field in the
+                returned record if those data haven't been returned in the
+                last metadata_interval seconds.
+
+            fields (dict): Mapping of field names to target types
+                (e.g., {'temp': 'float'}). If provided, ConvertFieldsTransform
+                is applied after parsing.
 
             delete_source_fields (bool): Remove original fields after conversion.
 
             delete_unconverted_fields (bool): Remove fields that were not converted.
-
-            metadata (dict): If field_patterns is not None, the metadata to send along with
-                             data records.
-
-            metadata_interval (float): If not None, include the description, units and
-                                       other metadata pertaining to each field in the
-                                       returned record if those data haven't been returned
-                                       in the last metadata_interval seconds.
         """
         super().__init__(**kwargs)  # processes 'quiet' and type hints
 
-        # Check for conflict
-        if field_patterns and definition_path:
-            raise ValueError('RegexParseTransform: Both field_patterns and definition_path '
-                             'specified. Please specify only one.')
-
-        self.devices = {}
-        self.device_types = {}
-        self.type_converters = {}
-
-        self.metadata = metadata or {}
-        self.metadata_interval = metadata_interval
-        self.metadata_last_sent = {}
-
-        # If field patterns not provided, look them up in definitions
-        if field_patterns is None:
-            definition_path = definition_path or DEFAULT_DEFINITION_PATH
-            # Load definitions populate self.devices and self.device_types
-            # And returns the aggregated patterns for the parser
-            field_patterns = self._load_definitions(definition_path)
-
-            # If metadata not explicitly provided, try to compile it from definitions
-            if not self.metadata and self.metadata_interval:
-                self._compile_metadata()
-
-        # 1. Initialize the Parser (RegexParser)
-        # We pass the aggregated patterns. RegexParser extracts fields based on regex names.
+        # Create the parser with all configuration
         self.parser = regex_parser.RegexParser(
             record_format=record_format,
             field_patterns=field_patterns,
             data_id=data_id,
+            definition_path=definition_path,
+            metadata=metadata,
+            metadata_interval=metadata_interval,
             quiet=self.quiet
         )
 
-        # 3. Converter for generic fields (passed in args)
+        # Optional generic field converter (for 'fields' parameter)
         self.converter = None
         if fields and ConvertFieldsTransform:
             self.converter = ConvertFieldsTransform(
@@ -159,169 +128,22 @@ class RegexParseTransform(Transform):
                 quiet=self.quiet
             )
 
-    def _load_definitions(self, definition_path):
-        """Load device definitions and return aggregated field patterns.
-        Populates self.devices and self.device_types.
-        """
-        field_patterns = {}
-
-        if not definition_path:
-            return field_patterns
-
-        def_files = []
-        for path_glob in definition_path.split(','):
-            def_files.extend(glob.glob(path_glob.strip()))
-
-        if not def_files:
-            return field_patterns
-
-        for filename in def_files:
-            # read_config handles includes recursively? No, we must call it.
-            new_defs = read_config.read_config(filename)
-            new_defs = read_config.expand_includes(new_defs)
-
-            # Store device_types
-            if 'device_types' in new_defs:
-                for dt_name, dt_def in new_defs['device_types'].items():
-                    self.device_types[dt_name] = dt_def
-                    # Aggregate formats (regexes)
-                    dt_formats = dt_def.get('format', {})
-                    if isinstance(dt_formats, dict):
-                        field_patterns.update(dt_formats)
-
-                    # Create cached component converter for this type
-                    # CSIRO format: fields: {name: {data_type: type}}
-                    # ConvertFieldsTransform format: {name: {data_type: type}} or {name: type}
-                    # It matches perfectly.
-                    dt_fields = dt_def.get('fields', {})
-                    if dt_fields and ConvertFieldsTransform:
-                        self.type_converters[dt_name] = ConvertFieldsTransform(
-                            fields=dt_fields,
-                            quiet=self.quiet
-                        )
-
-            # Store devices
-            if 'devices' in new_defs:
-                for d_name, d_def in new_defs['devices'].items():
-                    self.devices[d_name] = d_def
-
-        return field_patterns
-
-    def _compile_metadata(self):
-        """
-        Compile metadata from device definitions if available.
-        Logic adapted from RecordParser.
-        """
-        # It's a map from variable name to the device and device type it
-        # came from, along with device type variable and its units and
-        # description, if provided in the device type definition.
-        for device, device_def in self.devices.items():
-            device_type_name = device_def.get('device_type')
-            if not device_type_name:
-                continue
-
-            device_type_def = self.device_types.get(device_type_name)
-            if not device_type_def:
-                continue
-
-            device_type_fields = device_type_def.get('fields')
-            if not device_type_fields:
-                continue
-
-            fields = device_def.get('fields')
-            if not fields:
-                continue
-
-            # e.g. device_type_field = GPSTime, device_field = S330GPSTime
-            for device_type_field, device_field in fields.items():
-                # e.g. GPSTime: {'units':..., 'description':...}
-                field_desc = device_type_fields.get(device_type_field)
-
-                # field_desc might be a string (type) or dict (metadata) or None
-                if not field_desc or not isinstance(field_desc, dict):
-                    continue
-
-                self.metadata[device_field] = {
-                    'device': device,
-                    'device_type': device_type_name,
-                    'device_type_field': device_type_field,
-                }
-                # Copy relevant keys like units, description
-                for k in ['units', 'description']:
-                    if k in field_desc:
-                        self.metadata[device_field][k] = field_desc[k]
-
+    ############################
     def transform(self, record: str) -> Union[DASRecord, List[DASRecord], None]:
-        """
-        Parse the record, optionally convert fields, and return the result.
-        """
+        """Parse record and return DASRecord."""
         # See if it's something we can process, and if not, try digesting
-        if not self.can_process_record(record):  # BaseModule
-            return self.digest_record(record)  # BaseModule
+        if not self.can_process_record(record):  # inherited from BaseModule
+            return self.digest_record(record)  # inherited from BaseModule
 
-        # 1. Parse (Regex)
+        # Delegate to parser
         parsed_record = self.parser.parse_record(record)
 
         if not parsed_record:
             return None
 
-        # 2. Device-Specific Logic
-        # Try to match data_id to a known device
-        data_id = parsed_record.data_id
-        if data_id in self.devices:
-            device_def = self.devices[data_id]
-            device_type = device_def.get('device_type')
-
-            # A. Type Conversion (delegated to cached ConvertFieldsTransform)
-            if device_type in self.type_converters:
-                converter = self.type_converters[device_type]
-                parsed_record = converter.transform(parsed_record)
-                if not parsed_record:
-                    return None
-
-            # B. Field Renaming / Filtering
-            # Only retain fields that are in the device's 'fields' map
-            device_fields_map = device_def.get('fields', {})
-            if device_fields_map:
-                new_fields = {}
-                for original_name, mapped_name in device_fields_map.items():
-                    if original_name in parsed_record.fields:
-                        # Use the mapped name (value)
-                        new_fields[mapped_name] = parsed_record.fields[original_name]
-
-                parsed_record.fields = new_fields
-
-        # 3. Generic Converter (ConvertFieldsTransform)
-        # Apply this AFTER device logic if configured (e.g. explicit 'fields' arg)
+        # Apply optional generic converter
         if self.converter:
             parsed_record = self.converter.transform(parsed_record)
-            if not parsed_record:
-                return None
-
-        # 4. Metadata Injection
-        # If we have parsed fields, see if we also have metadata. Are we
-        # supposed to occasionally send it for our variables? Is it time
-        # to send it again?
-        if self.metadata and self.metadata_interval:
-            metadata_fields = {}
-            timestamp = parsed_record.timestamp or 0
-
-            for field_name in parsed_record.fields:
-                last_metadata_sent = self.metadata_last_sent.get(field_name, 0)
-                time_since_send = timestamp - last_metadata_sent
-
-                # Check if it's time to send
-                if time_since_send > self.metadata_interval:
-                    field_metadata = self.metadata.get(field_name)
-                    if field_metadata:
-                        metadata_fields[field_name] = field_metadata
-                        self.metadata_last_sent[field_name] = timestamp
-
-            # If we collected any metadata to send, attach it
-            if metadata_fields:
-                if parsed_record.metadata is None:
-                    parsed_record.metadata = {}
-                parsed_record.metadata['fields'] = metadata_fields
 
         return parsed_record
 

--- a/logger/transforms/regex_parse_transform.py
+++ b/logger/transforms/regex_parse_transform.py
@@ -14,6 +14,7 @@ have one, or to override the one that is there.
 """
 
 import sys
+import glob
 from typing import Union, Dict, List
 
 # Adjust paths as per your project structure
@@ -27,12 +28,15 @@ from logger.transforms.convert_fields_transform import ConvertFieldsTransform  #
 
 # Uses the 're' based parser (formerly used by RegexTransform)
 from logger.utils import regex_parser  # noqa: E402
+from logger.utils import read_config  # noqa: E402
+
+DEFAULT_DEFINITION_PATH = 'contrib/devices/*.yaml'
 
 
 class RegexParseTransform(Transform):
     r"""
-    Parses a string record into a Python dict (or DASRecord/JSON) using
-    regular expressions, with optional field type conversion.
+    Parses a string record into a DASRecord using regular expressions,
+    with optional field type conversion.
 
     This implementation uses the 're' module for parsing (via regex_parser)
     and does NOT depend on ParseTransform.
@@ -44,7 +48,6 @@ class RegexParseTransform(Transform):
         - class: RegexParseTransform
           module: logger.transforms.regex_parse_transform
           kwargs:
-            return_das_record: true
             data_id: gnsspo112593  # Overrides or fills in data_id
             field_patterns:
               GPZDA: '^\WGPZDA,(?P<utc_time>\d+\.\d+),(?P<day>\d{2}),(?P<month>\d{2}),
@@ -74,6 +77,7 @@ class RegexParseTransform(Transform):
                  record_format: str = None,
                  field_patterns: Union[List, Dict] = None,
                  data_id: str = None,
+                 definition_path: str = None,
 
                  # --- Type Conversion Arguments (ConvertFieldsTransform) ---
                  fields: Dict = None,
@@ -93,6 +97,10 @@ class RegexParseTransform(Transform):
             data_id (str): If specified, this string is used as the data_id for all records,
                            overriding any data_id extracted from the source record.
 
+            definition_path (str): Wildcarded path matching YAML definitions for devices.
+                                   Used only if 'field_patterns' is None.
+                                   Defaults to 'contrib/devices/*.yaml'.
+
             fields (dict): Mapping of field names to target types (e.g., {'temp': 'float'}).
                            If provided, ConvertFieldsTransform is instantiated internally.
 
@@ -103,6 +111,22 @@ class RegexParseTransform(Transform):
             delete_unconverted_fields (bool): Remove fields that were not converted.
         """
         super().__init__(**kwargs)  # processes 'quiet' and type hints
+
+        # Check for conflict
+        if field_patterns and definition_path:
+            raise ValueError('RegexParseTransform: Both field_patterns and definition_path '
+                             'specified. Please specify only one.')
+
+        # If field patterns not provided, look them up in definitions
+        if field_patterns is None:
+            definition_path = definition_path or DEFAULT_DEFINITION_PATH
+            field_patterns, loaded_fields = self._load_definitions(definition_path)
+            # Merge loaded fields (types) with passed fields argument
+            if loaded_fields:
+                if fields is None:
+                    fields = {}
+                loaded_fields.update(fields)
+                fields = loaded_fields
 
         # 1. Initialize the Parser (RegexParser)
         self.parser = regex_parser.RegexParser(
@@ -122,6 +146,47 @@ class RegexParseTransform(Transform):
                 delete_unconverted_fields=delete_unconverted_fields,
                 quiet=self.quiet
             )
+
+    def _load_definitions(self, definition_path):
+        """Load device definitions from YAML files and extract regex patterns and field types.
+        """
+        field_patterns = {}
+        fields = {}
+
+        if not definition_path:
+            return field_patterns, fields
+
+        # We can implement a simplified version of RecordParser._read_definitions
+        # tailored to what we need (regexes and types)
+        def_files = []
+        for path_glob in definition_path.split(','):
+            def_files.extend(glob.glob(path_glob.strip()))
+
+        if not def_files:
+            return field_patterns, fields
+
+        for filename in def_files:
+            new_defs = read_config.read_config(filename)
+            # We are interested mainly in 'device_types'
+            # (which contain 'format' and 'fields')
+            if 'device_types' in new_defs:
+                for dt_name, dt_def in new_defs['device_types'].items():
+                    # Extract formats (regexes)
+                    # format is typically dict {MsgType: regex}
+                    dt_formats = dt_def.get('format', {})
+                    if isinstance(dt_formats, dict):
+                        field_patterns.update(dt_formats)
+
+                    # Extract field types
+                    dt_fields = dt_def.get('fields', {})
+                    for field_name, field_def in dt_fields.items():
+                        # field_def might be a dict with 'data_type'
+                        if isinstance(field_def, dict):
+                            dtype = field_def.get('data_type')
+                            if dtype:
+                                fields[field_name] = dtype
+
+        return field_patterns, fields
 
     def transform(self, record: str) -> Union[DASRecord, List[DASRecord], None]:
         """

--- a/logger/transforms/regex_parse_transform.py
+++ b/logger/transforms/regex_parse_transform.py
@@ -2,11 +2,15 @@
 """
 Unified RegexParseTransform.
 
-This class unifies the functionality of RegexTransform and RegexParseTransform
-into a single, robust regex-based transformer.
+This class unifies the functionality of the CORIOLIX RegexTransform and
+CSIRO's RegexParseTransform into a single, robust regex-based transformer.
 
 It uses the pure-regex parsing engine (logger.utils.regex_parser) rather than
 the format-string parser, and allows for optional type conversion of fields.
+
+It also allows use of dicts of {message_type: regex} in field_patterns to capture
+message_type, and allows specifying a data_id, either if the data string doesn't
+have one, or to override the one that is there.
 """
 
 import sys

--- a/logger/utils/convert_fields.py
+++ b/logger/utils/convert_fields.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Utilities for converting field values to specified types."""
+
+import logging
+
+# Map string type names to actual python types/conversion functions.
+# Recognized types include:
+#   float, double -> float
+#   int, short, ushort, uint, long, ubyte, byte, hex -> int
+#   str, char, string, text -> str
+#   bool, boolean -> bool
+TYPE_MAP = {
+    'float': float,
+    'double': float,
+    'int': int,
+    'short': int,
+    'ushort': int,
+    'uint': int,
+    'long': int,
+    'ubyte': int,
+    'byte': int,
+    'str': str,
+    'char': str,
+    'string': str,
+    'text': str,
+    'bool': bool,
+    'boolean': bool,
+    'hex': lambda x: int(str(x), 16),  # Handles "1A", "0x1A", etc.
+}
+
+
+def convert_lat_lon(value, direction, rounding_decimals=5):
+    """
+    Convert NMEA style lat/lon (DDMM.MMMM) and direction (N/S/E/W)
+    to decimal degrees.
+
+    Args:
+        value: NMEA format value (e.g., "4807.038" for 48°07.038')
+        direction: Cardinal direction ('N', 'S', 'E', 'W')
+        rounding_decimals: Number of decimal places to round to
+
+    Returns:
+        Decimal degrees as float, or None if conversion fails
+    """
+    try:
+        val = float(value)
+        # NMEA format is roughly DDMM.MMMM
+        # Degrees is the integer part of val / 100
+        degrees = int(val / 100)
+        minutes = val - (degrees * 100)
+        decimal = degrees + (minutes / 60)
+
+        if direction.upper() in ['S', 'W']:
+            decimal = -decimal
+
+        return round(decimal, rounding_decimals)
+    except (ValueError, TypeError, AttributeError) as e:
+        logging.warning(f'Failed to convert lat/lon: value=\'{value}\', '
+                        f'direction=\'{direction}\' - {e}')
+        return None
+
+
+def convert_field_value(value, target_type_str, quiet=False):
+    """
+    Convert a single field value to the specified type.
+
+    Args:
+        value: The value to convert
+        target_type_str: String name of target type (e.g., 'float', 'int', 'str')
+        quiet: If True, suppress warning messages
+
+    Returns:
+        Converted value, or original value if conversion fails
+    """
+    converter = TYPE_MAP.get(target_type_str)
+    if not converter:
+        if not quiet:
+            logging.warning(f'Unknown type \'{target_type_str}\' requested')
+        return value
+
+    try:
+        # Special case to head off ValueError of int("123.0")
+        if isinstance(value, str) and converter is int:
+            try:
+                value = float(value)
+            except ValueError:
+                # Not a float string, let int() call below handle/fail it naturally
+                pass
+
+        return converter(value)
+    except ValueError:
+        if not quiet:
+            logging.warning(f'Failed to convert value \'{value}\' '
+                            f'(type={type(value).__name__}) to \'{target_type_str}\'')
+        return value
+
+
+def convert_fields(fields, field_specs, lat_lon_specs=None,
+                   delete_source_fields=False, delete_unconverted_fields=False,
+                   quiet=False):
+    """
+    Convert fields in a dictionary according to specifications.
+
+    This is a shared utility used by ConvertFieldsTransform and can be used
+    directly by parsers for field conversion.
+
+    Args:
+        fields: Dict of field_name -> value (modified in place)
+        field_specs: Dict of field_name -> target_type or {data_type: target_type}
+        lat_lon_specs: Dict of target_field -> (value_field, direction_field)
+                      for NMEA lat/lon conversion
+        delete_source_fields: If True, remove source fields after lat/lon conversion
+        delete_unconverted_fields: If True, remove fields not involved in conversion
+        quiet: If True, suppress warning messages
+
+    Returns:
+        The modified fields dict, or None if no fields remain after processing
+    """
+    if not fields:
+        return None
+
+    # Track which fields were successfully converted or used
+    processed_fields = set()
+
+    # 1. Handle simple Type Conversions
+    if field_specs:
+        for field_name, field_def in field_specs.items():
+            if field_name not in fields:
+                continue
+
+            # Extract target type from dict, or use string directly
+            if isinstance(field_def, dict):
+                target_type_str = field_def.get('data_type')
+            elif isinstance(field_def, str):
+                target_type_str = field_def
+            else:
+                continue
+
+            if not target_type_str:
+                continue
+
+            val = fields[field_name]
+            converter = TYPE_MAP.get(target_type_str)
+            if converter:
+                try:
+                    # Special case to head off ValueError of int("123.0")
+                    if isinstance(val, str) and converter is int:
+                        try:
+                            val = float(val)
+                        except ValueError:
+                            pass
+
+                    fields[field_name] = converter(val)
+                    processed_fields.add(field_name)
+                except ValueError:
+                    if not quiet:
+                        logging.warning(f'Failed to convert field \'{field_name}\': '
+                                        f'value=\'{val}\' (type={type(val).__name__}) '
+                                        f'to target_type=\'{target_type_str}\'')
+            else:
+                if not quiet:
+                    logging.warning(f'Unknown type \'{target_type_str}\' '
+                                    f'requested for field \'{field_name}\'')
+
+    # 2. Handle Lat/Lon Conversions
+    if lat_lon_specs:
+        for target_field, (val_field, dir_field) in lat_lon_specs.items():
+            if val_field not in fields or dir_field not in fields:
+                continue
+
+            val = fields[val_field]
+            direction = fields[dir_field]
+
+            decimal_degrees = convert_lat_lon(val, direction)
+
+            if decimal_degrees is not None:
+                fields[target_field] = decimal_degrees
+                processed_fields.add(target_field)
+
+                # Mark source fields as processed
+                if delete_source_fields:
+                    processed_fields.add(val_field)
+                    processed_fields.add(dir_field)
+
+                    # Delete source fields, but NOT if source == target
+                    if val_field in fields and val_field != target_field:
+                        del fields[val_field]
+                    if dir_field in fields and dir_field != target_field:
+                        del fields[dir_field]
+
+    # 3. Clean up unconverted fields
+    if delete_unconverted_fields:
+        all_fields = list(fields.keys())
+        for f in all_fields:
+            if f not in processed_fields:
+                del fields[f]
+
+    # If no fields remain, return None
+    if not fields:
+        return None
+
+    return fields

--- a/logger/utils/convert_fields.py
+++ b/logger/utils/convert_fields.py
@@ -6,7 +6,7 @@ import logging
 # Map string type names to actual python types/conversion functions.
 # Recognized types include:
 #   float, double -> float
-#   int, short, ushort, uint, long, ubyte, byte, hex -> int
+#   int, short, ushort, uint, long, ubyte, byte, hex_int -> int
 #   str, char, string, text -> str
 #   bool, boolean -> bool
 TYPE_MAP = {
@@ -25,7 +25,7 @@ TYPE_MAP = {
     'text': str,
     'bool': bool,
     'boolean': bool,
-    'hex': lambda x: int(str(x), 16),  # Handles "1A", "0x1A", etc.
+    'hex_int': lambda x: int(str(x), 16),  # Handles "1A", "0x1A", etc.
 }
 
 

--- a/logger/utils/read_config.py
+++ b/logger/utils/read_config.py
@@ -163,6 +163,8 @@ def expand_includes(input_dict: dict) -> Dict[str, Any]:
         # Process each included file or pattern
         for include_pattern in input_dict['includes']:
             # Expand wildcards to get list of matching files
+            if isinstance(include_pattern, str):
+                include_pattern = include_pattern.strip()
             matching_files = expand_wildcards(include_pattern, base_dir)
 
             # Process each matching file

--- a/logger/utils/record_parser.py
+++ b/logger/utils/record_parser.py
@@ -8,7 +8,6 @@ contrib/devices/README.md for a description of the format these
 definitions should take.
 """
 import datetime
-import glob
 import json
 import logging
 import pprint
@@ -23,8 +22,9 @@ except ImportError:
 # Append openrvdas root to syspath prior to importing openrvdas modules
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
-from logger.utils import read_config  # noqa: E402
 from logger.utils.das_record import DASRecord  # noqa: E402
+from logger.utils.read_config import load_definitions  # noqa: E402
+from logger.utils.das_record import collect_metadata_for_fields  # noqa: E402
 
 # Dict of format types that extend the default formats recognized by the
 # parse module.
@@ -121,7 +121,7 @@ class RecordParser:
         else:
             # Fill in the devices and device_types - NOTE: we won't be using
             # these if 'field_patterns' is provided as an argument.
-            definitions = self._new_read_definitions(definition_path)
+            definitions = load_definitions(definition_path)
             self.devices = definitions.get('devices', {})
             self.device_types = definitions.get('device_types', {})
 
@@ -286,24 +286,11 @@ class RecordParser:
         if message_type:
             parsed_record['message_type'] = message_type
 
-        # If we have parsed fields, see if we also have metadata. Are we
-        # supposed to occasionally send it for our variables? Is it time
-        # to send it again?
-        metadata_fields = {}
-        if self.metadata and self.metadata_interval:
-            for field_name in fields:
-                last_metadata_sent = self.metadata_last_sent.get(field_name, 0)
-                time_since_send = timestamp - last_metadata_sent
-                if time_since_send > self.metadata_interval:
-                    field_metadata = self.metadata.get(field_name)
-                    if field_metadata:
-                        metadata_fields[field_name] = field_metadata
-                        self.metadata_last_sent[field_name] = timestamp
-        if metadata_fields:
-            metadata = {'fields': metadata_fields}
-        else:
-            metadata = None
-
+        # Metadata Injection - use shared utility
+        metadata = collect_metadata_for_fields(
+            fields, timestamp, self.metadata,
+            self.metadata_interval, self.metadata_last_sent
+        )
         if metadata:
             parsed_record['metadata'] = metadata
 
@@ -450,115 +437,3 @@ class RecordParser:
         else:
             raise ValueError('Passed field_patterns must be str, list or dict. Found %s: %s'
                              % (type(field_patterns), str(field_patterns)))
-
-    ############################
-    def _read_definitions(self, filespec_paths):
-        """Read the files on the filespec_paths and return dictionary of
-        accumulated definitions.
-        """
-        definitions = {}
-        for filespec in filespec_paths.split(','):
-            filenames = glob.glob(filespec)
-            if not filenames:
-                logging.warning('No files match definition file spec "%s"', filespec)
-
-            for filename in filenames:
-                file_definitions = read_config.read_config(filename)
-
-                for new_def_name, new_def in file_definitions.items():
-                    if new_def_name in definitions:
-                        logging.warning('Duplicate definition for "%s" found in %s',
-                                        new_def_name, filename)
-                    definitions[new_def_name] = new_def
-        return definitions
-
-    ############################
-    def _new_read_definitions(self, filespec_paths, definitions=None):
-        """Read the files on the filespec_paths and return dictionary of
-        accumulated definitions.
-
-        filespec_paths - a list of possibly-globbed filespecs to be read
-
-        definitions - optional dict of pre-existing definitions that will
-                      be added to. Typically this will be omitted on a base call,
-                      but may be added to when recursing. Passing it in allows
-                      flagging when items are defined more than once.
-        """
-        # If nothing was passed in, start with base case.
-        definitions = definitions or {'devices': {}, 'device_types': {}}
-
-        for filespec in filespec_paths.split(','):
-            filenames = glob.glob(filespec)
-            if not filenames:
-                logging.warning('No files match definition file spec "%s"', filespec)
-
-            for filename in filenames:
-                file_definitions = read_config.read_config(filename)
-
-                for key, val in file_definitions.items():
-                    # If we have a dict of device definitions, copy them into the
-                    # 'devices' key of our definitions.
-                    if key == 'devices':
-                        if not isinstance(val, dict):
-                            logging.error('"devices" values in file %s must be dict. '
-                                          'Found type "%s"', filename, type(val))
-                            return None
-
-                        for device_name, device_def in val.items():
-                            if device_name in definitions['devices']:
-                                logging.warning('Duplicate definition for "%s" found in %s',
-                                                device_name, filename)
-                            definitions['devices'][device_name] = device_def
-
-                    # If we have a dict of device_type definitions, copy them into the
-                    # 'device_types' key of our definitions.
-                    elif key == 'device_types':
-                        if not isinstance(val, dict):
-                            logging.error('"device_typess" values in file %s must be dict. '
-                                          'Found type "%s"', filename, type(val))
-                            return None
-
-                        for device_type_name, device_type_def in val.items():
-                            if device_type_name in definitions['device_types']:
-                                logging.warning('Duplicate definition for "%s" found in %s',
-                                                device_type_name, filename)
-                            definitions['device_types'][device_type_name] = device_type_def
-
-                    # If we're including other files, recurse inelegantly
-                    elif key == 'includes':
-                        if not type(val) in [str, list]:
-                            logging.error('"includes" values in file %s must be either '
-                                          'a list or a simple string. Found type "%s"',
-                                          filename, type(val))
-                            return None
-
-                        if isinstance(val, str):
-                            val = [val]
-                        for filespec in val:
-                            new_defs = self._new_read_definitions(filespec, definitions)
-                            definitions['devices'].update(new_defs.get('devices', {}))
-                            definitions['device_types'].update(new_defs.get('device_types', {}))
-
-                    # If it's not an includes/devices/device_types def, assume
-                    # it's a (deprecated) top-level device or device_type
-                    # definition. Try adding it to the right place.
-                    else:
-                        category = val.get('category')
-                        if category not in ['device', 'device_type']:
-                            logging.warning('Top-level definition "%s" in file %s is not '
-                                            'category "device" or "device_type". '
-                                            'Category is "%s" - ignoring', category)
-                            continue
-                        if category == 'device':
-                            if key in definitions['devices']:
-                                logging.warning('Duplicate definition for "%s" found in %s',
-                                                key, filename)
-                            definitions['devices'][key] = val
-                        else:
-                            if key in definitions['device_types']:
-                                logging.warning('Duplicate definition for "%s" found in %s',
-                                                key, filename)
-                            definitions['device_types'][key] = val
-
-        # Finally, return the accumulated definitions
-        return definitions

--- a/logger/utils/regex_parser.py
+++ b/logger/utils/regex_parser.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+
+"""Tools for parsing NMEA and other text records using regex.
+"""
+import datetime
+import json
+import logging
+import re
+import pprint
+import sys
+import time
+
+from os.path import dirname, realpath
+
+
+# Append openrvdas root to syspath prior to importing openrvdas modules
+sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
+
+from logger.utils.das_record import DASRecord  # noqa: E402
+
+# Note: this is a "permissive" regex. It looks for data_id and timestamp prior to field_string,
+# But still parses field_string if they are absent
+# Works for both "data_id timestamp fields" but also parses "fields" if
+# data_id or timestamp are missing
+
+DEFAULT_RECORD_FORMAT = r"^(?:(?P<data_id>\w+)\s+(?P<timestamp>[0-9TZ:\-\.]*)\s+)?(?P<field_string>(.|\r|\n)*)"  # noqa: E501
+
+
+################################################################################
+class RegexParser:
+    ############################
+    def __init__(self,
+                 record_format=None,
+                 field_patterns=None,
+                 data_id=None,
+                 return_das_record=False,
+                 return_json=False,
+                 quiet=False):
+        r"""Create a parser that will parse field values out of a text record
+        and return either a Python dict of data_id, timestamp and fields,
+        a JSON encoding of that dict, or a binary DASRecord.
+        ```
+        record_format - string for re.match() to use to break out data_id
+            and timestamp from the rest of the message. By default this will
+            look for 'data_id timestamp field_string', where 'field_string'
+            is a str containing the fields to be parsed.
+
+        field_patterns
+            If not None, either
+            - a list of regex patterns to be tried
+            - a dict of message_type:regex patterns to be tried. When one
+              matches, the record's message_type is set accordingly.
+
+        data_id
+            If specified, this string is used as the data_id for all records,
+            overriding any data_id extracted from the source record.
+
+        return_json - return the parsed fields as a JSON encoded dict
+
+        return_das_record - return the parsed fields as a DASRecord object
+
+        quiet - if not False, don't complain when unable to parse a record.
+        ```
+
+        **Example:**
+
+        .. code-block:: python
+
+            parser = RegexParser(
+                data_id='s330',
+                field_patterns={
+                    'GPGGA': r'^\$GPGGA,(?P<utc>\d+\.\d+),(?P<lat>\d+\.\d+),'
+                             r'(?P<lat_dir>[NS]),(?P<lon>\d+\.\d+),'
+                             r'(?P<lon_dir>[EW]).*',
+                    'GPHDT': r'^\$GPHDT,(?P<heading>\d+\.\d+),T.*'
+                }
+            )
+
+            # Record with implicit timestamp/data_id handling (or overrides)
+            record = '$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47'
+            result = parser.parse_record(record)
+
+            # result['fields'] will contain:
+            # {'utc': '123519', 'lat': '4807.038', 'lat_dir': 'N',
+            #  'lon': '01131.000', 'lon_dir': 'E'}
+        """
+        self.quiet = quiet
+        self.field_patterns = field_patterns
+        self.record_format = record_format or DEFAULT_RECORD_FORMAT
+        self.compiled_record_format = re.compile(self.record_format)
+        self.return_das_record = return_das_record
+        self.return_json = return_json
+        self.data_id = data_id  # Store the data_id override
+
+        if return_das_record and return_json:
+            raise ValueError('Only one of return_json and return_das_record '
+                             'may be true.')
+
+        # If we've been explicitly given the field_patterns we're to use for
+        # parsing, compile them now.
+        if field_patterns:
+            if isinstance(field_patterns, list):
+                self.compiled_field_patterns = [
+                    re.compile(pattern)
+                    for pattern in field_patterns
+                ]
+            elif isinstance(field_patterns, dict):
+                self.compiled_field_patterns = {
+                    message_type: re.compile(pattern)
+                    for (message_type, pattern) in field_patterns.items()
+                }
+            else:
+                raise ValueError('field_patterns must either be a list of patterns or '
+                                 'dict of message_type:pattern pairs. Found type '
+                                 f'{type(field_patterns)}')
+
+    ############################
+    def parse_record(self, record):
+        """Parse an id-prefixed text record into a Python dict of
+        data_id, timestamp and fields.
+        """
+        if not record:
+            return None
+        if not isinstance(record, str):
+            logging.info('Record is not a string: "%s"', record)
+            return None
+        try:
+            parsed_record = self.compiled_record_format.match(record).groupdict()
+        except (ValueError, AttributeError):
+            if not self.quiet:
+                logging.warning('Unable to parse record into "%s"', self.record_format)
+                logging.warning('Record: %s', record)
+            return None
+
+        if parsed_record is None:
+            return None
+
+        # Logic to determine data_id:
+        # 1. If self.data_id is set (in __init__), use it (Override).
+        # 2. Else, look for 'data_id' extracted from the record via regex.
+        # 3. If that fails, default to 'unknown'.
+        if self.data_id:
+            data_id = self.data_id
+        else:
+            data_id = parsed_record.get('data_id', None)
+            if not data_id:
+                data_id = 'unknown'
+
+        # Convert timestamp to numeric, if it's there.
+        # Initialize to None first to avoid UnboundLocalError if 'timestamp'
+        # is not in the regex groups.
+        timestamp = None
+        timestamp_text = parsed_record.get('timestamp', None)
+
+        if timestamp_text is not None:
+            timestamp = self.convert_timestamp(timestamp_text)
+            if timestamp is not None:
+                parsed_record['timestamp'] = timestamp
+
+        # If no timestamp found, DASRecord will usually default to time.time()
+        # if passed None.
+        if timestamp is None:
+            timestamp = time.time()
+
+        # Extract the field string we're going to parse;
+        # remove trailing whitespace.
+        field_string = parsed_record.get('field_string', None)
+        if field_string is not None:
+            field_string = field_string.rstrip()
+            del parsed_record['field_string']
+
+        message_type = None
+        fields = {}
+        if field_string:
+            # If we've been given a set of field_patterns to apply,
+            # use the first that matches.
+            # Shortcut that lets us iterate through a list or a dict with the same
+            # invocation. With a list, it returns (None, value); with a dict it
+            # returns (key, value).
+            def iterate_patterns(obj):
+                return (obj.items() if isinstance(obj, dict) else ((None, v) for v in obj))
+
+            if self.field_patterns:
+                for message_type, pattern in iterate_patterns(self.compiled_field_patterns):
+                    try:
+                        try_parse = pattern.match(field_string)
+                        # Did we find a parse that matched?
+                        # If so, return its fields
+                        if try_parse:
+                            fields = try_parse.groupdict()
+                            break
+                    except Exception as e:
+                        logging.error(e)
+
+        if fields:
+            parsed_record['fields'] = fields
+
+        logging.debug('Created parsed record: %s', pprint.pformat(parsed_record))
+
+        metadata = None
+
+        # What are we going to do with the result we've created?
+        if self.return_das_record:
+            try:
+                return DASRecord(data_id=data_id, timestamp=timestamp,
+                                 message_type=message_type,
+                                 fields=fields, metadata=metadata)
+            except KeyError:
+                return None
+
+        elif self.return_json:
+            # Note: We must ensure the 'data_id' key is updated in the dict
+            # if we are returning JSON, as parsed_record still contains the
+            # original regex match dict (minus field_string).
+            parsed_record['data_id'] = data_id
+            if 'timestamp' not in parsed_record:
+                parsed_record['timestamp'] = timestamp
+            return json.dumps(parsed_record)
+        else:
+            # Same as JSON case, update the dict before returning
+            parsed_record['data_id'] = data_id
+            if 'timestamp' not in parsed_record:
+                parsed_record['timestamp'] = timestamp
+            return parsed_record
+
+    ############################
+    def convert_timestamp(self, datetime_text):
+        """Validates a datetime string and converts to numeric.
+        """
+
+        DEFAULT_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+        try:
+            datetime_ti = datetime.datetime.strptime(
+                datetime_text, DEFAULT_FORMAT)
+        except ValueError:
+            logging.debug("Incorrect datetime format.")
+            return None
+
+        if datetime_ti:
+            # Explicitly set UTC timezone because the format expects 'Z'
+            # .replace(tzinfo=...) ensures .timestamp() treats it as UTC
+            # regardless of the local system clock.
+            timestamp = datetime_ti.replace(tzinfo=datetime.timezone.utc).timestamp()
+            return timestamp

--- a/logger/utils/regex_parser.py
+++ b/logger/utils/regex_parser.py
@@ -107,6 +107,9 @@ class RegexParser:
         else:
             data_id = parsed_record.get('data_id', None)
             if not data_id:
+                if not self.quiet:
+                    logging.warning('No data_id found in record and none specified. '
+                                    'Defaulting to "unknown".')
                 data_id = 'unknown'
 
         # Convert timestamp to numeric, if it's there.

--- a/test/logger/transforms/test_convert_fields_transform.py
+++ b/test/logger/transforms/test_convert_fields_transform.py
@@ -82,9 +82,9 @@ class TestConvertFieldsTransform(unittest.TestCase):
     def test_hex_conversion(self):
         """Test converting hex strings to integers."""
         t = ConvertFieldsTransform(fields={
-            'flag_a': 'hex',
-            'flag_b': 'hex',
-            'prefixed': 'hex'
+            'flag_a': 'hex_int',
+            'flag_b': 'hex_int',
+            'prefixed': 'hex_int'
         })
 
         input_dict = {

--- a/test/logger/transforms/test_regex_parse_transform.py
+++ b/test/logger/transforms/test_regex_parse_transform.py
@@ -42,6 +42,14 @@ class TestRegexParseTransform(unittest.TestCase):
         self.assertEqual(result.fields['temp'], 23.5)
         self.assertIsInstance(result.fields['temp'], float)
 
+    def test_conflict_error(self):
+        """Test that defining both field_patterns and definition_path raises ValueError."""
+        with self.assertRaises(ValueError):
+            RegexParseTransform(
+                field_patterns=[self.field_pattern],
+                definition_path='some/path.yaml'
+            )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/logger/transforms/test_regex_parse_transform.py
+++ b/test/logger/transforms/test_regex_parse_transform.py
@@ -4,97 +4,62 @@ import json
 import sys
 from os.path import dirname, realpath
 
-# Add the proper path so imports work as if running in the package structure
-# path: test/logger/utils/test_regex_parser.py -> root (4 levels up)
 sys.path.append(dirname(dirname(dirname(dirname(realpath(__file__))))))
 
-from logger.utils.regex_parser import RegexParser  # noqa: E402
-from logger.utils.das_record import DASRecord  # noqa: E402
+from logger.transforms.regex_parse_transform import RegexParseTransform
+from logger.utils.das_record import DASRecord
 
-
-class TestRegexParser(unittest.TestCase):
+class TestRegexParseTransform(unittest.TestCase):
 
     def setUp(self):
-        # A simple record: data_id timestamp field_string
         self.sample_record = "sensor1 2023-01-01T12:00:00.000Z temp=23.5 humidity=60"
-        self.no_id_record = "2023-01-01T12:00:00.000Z temp=23.5"
-
-        # A pattern to extract fields
         self.field_pattern = r"temp=(?P<temp>[\d\.]+)\s+humidity=(?P<humidity>[\d\.]+)"
 
-    def test_basic_parsing(self):
-        """Test standard parsing extracting data_id and timestamp from record."""
-        parser = RegexParser(field_patterns=[self.field_pattern])
-        result = parser.parse_record(self.sample_record)
-
+    def test_transform_dict(self):
+        """Test transforming to a dictionary (default)."""
+        transform = RegexParseTransform(field_patterns=[self.field_pattern])
+        result = transform.transform(self.sample_record)
+        
+        self.assertIsInstance(result, dict)
         self.assertEqual(result['data_id'], 'sensor1')
-        self.assertEqual(result['timestamp'], 1672574400.0)
         self.assertEqual(result['fields']['temp'], '23.5')
-        self.assertEqual(result['fields']['humidity'], '60')
 
-    def test_data_id_override(self):
-        """Test that passing data_id to __init__ overrides the record's data_id."""
-        # Record says 'sensor1', but we initialize with 'override_id'
-        parser = RegexParser(field_patterns=[self.field_pattern], data_id='override_id')
-        result = parser.parse_record(self.sample_record)
-
-        self.assertEqual(result['data_id'], 'override_id')
-
-    def test_data_id_fallback(self):
-        """Test that data_id arg fills in when record has no data_id."""
-        # Using a format that doesn't look for data_id at the start
-        # e.g., just timestamp and fields
-        record_format = r"(?P<timestamp>[0-9TZ:\-\.]*)\s+(?P<field_string>.*)"
-        parser = RegexParser(record_format=record_format, data_id='fixed_id')
-
-        result = parser.parse_record(self.no_id_record)
-        self.assertEqual(result['data_id'], 'fixed_id')
-
-    def test_unknown_data_id(self):
-        """Test default 'unknown' if no data_id in record and no override provided."""
-        record_format = r"(?P<timestamp>[0-9TZ:\-\.]*)\s+(?P<field_string>.*)"
-        parser = RegexParser(record_format=record_format)  # No data_id arg
-
-        result = parser.parse_record(self.no_id_record)
-        self.assertEqual(result['data_id'], 'unknown')
-
-    def test_return_das_record(self):
-        """Test returning a DASRecord object."""
-        parser = RegexParser(field_patterns=[self.field_pattern], return_das_record=True)
-        result = parser.parse_record(self.sample_record)
-
+    def test_transform_das_record(self):
+        """Test transforming to a DASRecord."""
+        transform = RegexParseTransform(field_patterns=[self.field_pattern], return_das_record=True)
+        result = transform.transform(self.sample_record)
+        
         self.assertIsInstance(result, DASRecord)
         self.assertEqual(result.data_id, 'sensor1')
         self.assertEqual(result.fields['temp'], '23.5')
 
-    def test_return_json(self):
-        """Test returning a JSON string."""
-        parser = RegexParser(field_patterns=[self.field_pattern], return_json=True)
-        result = parser.parse_record(self.sample_record)
-
+    def test_transform_json(self):
+        """Test transforming to a JSON string."""
+        transform = RegexParseTransform(field_patterns=[self.field_pattern], return_json=True)
+        result = transform.transform(self.sample_record)
+        
         self.assertIsInstance(result, str)
-        parsed_json = json.loads(result)
-        self.assertEqual(parsed_json['data_id'], 'sensor1')
-        self.assertEqual(parsed_json['fields']['temp'], '23.5')
+        parsed = json.loads(result)
+        self.assertEqual(parsed['data_id'], 'sensor1')
+        self.assertEqual(parsed['fields']['temp'], '23.5')
 
-    def test_message_type_dict(self):
-        """Test using a dictionary of message types for field patterns."""
-        patterns = {
-            'weather': r"temp=(?P<temp>[\d\.]+)",
-            'nav': r"lat=(?P<lat>[\d\.]+)"
-        }
-        parser = RegexParser(field_patterns=patterns)
+    def test_data_id_override(self):
+        """Test overriding data_id."""
+        transform = RegexParseTransform(field_patterns=[self.field_pattern], data_id='my_sensor')
+        result = transform.transform(self.sample_record)
+        self.assertEqual(result['data_id'], 'my_sensor')
 
-        # Test matching first pattern
-        rec1 = "sensor1 2023-01-01T12:00:00Z temp=23.5"
-        res1 = parser.parse_record(rec1)
-        self.assertEqual(res1['fields']['temp'], '23.5')
-
-        # Test matching second pattern
-        rec2 = "sensor1 2023-01-01T12:00:00Z lat=45.0"
-        res2 = parser.parse_record(rec2)
-        self.assertEqual(res2['fields']['lat'], '45.0')
-
+    def test_field_conversion(self):
+        """Test integrating with field conversion (float)."""
+        # We need to mock or ensure ConvertFieldsTransform logic works.
+        # Assuming ConvertFieldsTransform is working (it's imported).
+        fields_map = {'temp': 'float'}
+        transform = RegexParseTransform(field_patterns=[self.field_pattern], fields=fields_map)
+        
+        result = transform.transform(self.sample_record)
+        # Temp should be a float now, not a string
+        self.assertEqual(result['fields']['temp'], 23.5)
+        self.assertIsInstance(result['fields']['temp'], float)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/logger/transforms/test_regex_parse_transform.py
+++ b/test/logger/transforms/test_regex_parse_transform.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 import unittest
-import json
 import sys
 from os.path import dirname, realpath
 
 sys.path.append(dirname(dirname(dirname(dirname(realpath(__file__))))))
 
-from logger.transforms.regex_parse_transform import RegexParseTransform
-from logger.utils.das_record import DASRecord
+from logger.transforms.regex_parse_transform import RegexParseTransform  # noqa: E402
+from logger.utils.das_record import DASRecord  # noqa: E402
+
 
 class TestRegexParseTransform(unittest.TestCase):
 
@@ -15,39 +15,20 @@ class TestRegexParseTransform(unittest.TestCase):
         self.sample_record = "sensor1 2023-01-01T12:00:00.000Z temp=23.5 humidity=60"
         self.field_pattern = r"temp=(?P<temp>[\d\.]+)\s+humidity=(?P<humidity>[\d\.]+)"
 
-    def test_transform_dict(self):
-        """Test transforming to a dictionary (default)."""
+    def test_transform(self):
+        """Test transforming to a DASRecord (default behavior)."""
         transform = RegexParseTransform(field_patterns=[self.field_pattern])
         result = transform.transform(self.sample_record)
-        
-        self.assertIsInstance(result, dict)
-        self.assertEqual(result['data_id'], 'sensor1')
-        self.assertEqual(result['fields']['temp'], '23.5')
 
-    def test_transform_das_record(self):
-        """Test transforming to a DASRecord."""
-        transform = RegexParseTransform(field_patterns=[self.field_pattern], return_das_record=True)
-        result = transform.transform(self.sample_record)
-        
         self.assertIsInstance(result, DASRecord)
         self.assertEqual(result.data_id, 'sensor1')
         self.assertEqual(result.fields['temp'], '23.5')
-
-    def test_transform_json(self):
-        """Test transforming to a JSON string."""
-        transform = RegexParseTransform(field_patterns=[self.field_pattern], return_json=True)
-        result = transform.transform(self.sample_record)
-        
-        self.assertIsInstance(result, str)
-        parsed = json.loads(result)
-        self.assertEqual(parsed['data_id'], 'sensor1')
-        self.assertEqual(parsed['fields']['temp'], '23.5')
 
     def test_data_id_override(self):
         """Test overriding data_id."""
         transform = RegexParseTransform(field_patterns=[self.field_pattern], data_id='my_sensor')
         result = transform.transform(self.sample_record)
-        self.assertEqual(result['data_id'], 'my_sensor')
+        self.assertEqual(result.data_id, 'my_sensor')
 
     def test_field_conversion(self):
         """Test integrating with field conversion (float)."""
@@ -55,11 +36,12 @@ class TestRegexParseTransform(unittest.TestCase):
         # Assuming ConvertFieldsTransform is working (it's imported).
         fields_map = {'temp': 'float'}
         transform = RegexParseTransform(field_patterns=[self.field_pattern], fields=fields_map)
-        
+
         result = transform.transform(self.sample_record)
         # Temp should be a float now, not a string
-        self.assertEqual(result['fields']['temp'], 23.5)
-        self.assertIsInstance(result['fields']['temp'], float)
+        self.assertEqual(result.fields['temp'], 23.5)
+        self.assertIsInstance(result.fields['temp'], float)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/logger/transforms/test_regex_parse_transform.py
+++ b/test/logger/transforms/test_regex_parse_transform.py
@@ -50,9 +50,9 @@ class TestRegexParseTransform(unittest.TestCase):
                 definition_path='some/path.yaml'
             )
 
-    @mock.patch('logger.transforms.regex_parse_transform.glob.glob')
-    @mock.patch('logger.transforms.regex_parse_transform.read_config.read_config')
-    @mock.patch('logger.transforms.regex_parse_transform.read_config.expand_includes')
+    @mock.patch('logger.utils.read_config.glob.glob')
+    @mock.patch('logger.utils.read_config.read_config')
+    @mock.patch('logger.utils.read_config.expand_includes')
     def test_definition_path(self, mock_expand, mock_read, mock_glob):
         """Test loading definitions from path with device mapping."""
         # Setup mocks
@@ -150,9 +150,9 @@ class TestRegexParseTransform(unittest.TestCase):
         self.assertIn('fields', result_3.metadata)
         self.assertEqual(result_3.metadata['fields']['temp']['units'], 'C')
 
-    @mock.patch('logger.transforms.regex_parse_transform.glob.glob')
-    @mock.patch('logger.transforms.regex_parse_transform.read_config.read_config')
-    @mock.patch('logger.transforms.regex_parse_transform.read_config.expand_includes')
+    @mock.patch('logger.utils.read_config.glob.glob')
+    @mock.patch('logger.utils.read_config.read_config')
+    @mock.patch('logger.utils.read_config.expand_includes')
     def test_metadata_compilation(self, mock_expand, mock_read, mock_glob):
         """Test that metadata is correctly compiled from device definitions."""
         mock_glob.return_value = ['/defs.yaml']
@@ -183,9 +183,10 @@ class TestRegexParseTransform(unittest.TestCase):
 
         # Check if internal metadata structure was built correctly
         # Mapped field 'Temperature' should have metadata from 'RawTemp'
-        self.assertIn('Temperature', transform.metadata)
-        self.assertEqual(transform.metadata['Temperature']['units'], 'C')
-        self.assertEqual(transform.metadata['Temperature']['description'], 'Raw Temp')
+        # Note: metadata is now in the parser, not the transform
+        self.assertIn('Temperature', transform.parser.metadata)
+        self.assertEqual(transform.parser.metadata['Temperature']['units'], 'C')
+        self.assertEqual(transform.parser.metadata['Temperature']['description'], 'Raw Temp')
 
 
 if __name__ == '__main__':

--- a/test/logger/transforms/test_regex_parse_transform.py
+++ b/test/logger/transforms/test_regex_parse_transform.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import unittest
+import json
+import sys
+from os.path import dirname, realpath
+
+# Add the proper path so imports work as if running in the package structure
+# path: test/logger/utils/test_regex_parser.py -> root (4 levels up)
+sys.path.append(dirname(dirname(dirname(dirname(realpath(__file__))))))
+
+from logger.utils.regex_parser import RegexParser  # noqa: E402
+from logger.utils.das_record import DASRecord  # noqa: E402
+
+
+class TestRegexParser(unittest.TestCase):
+
+    def setUp(self):
+        # A simple record: data_id timestamp field_string
+        self.sample_record = "sensor1 2023-01-01T12:00:00.000Z temp=23.5 humidity=60"
+        self.no_id_record = "2023-01-01T12:00:00.000Z temp=23.5"
+
+        # A pattern to extract fields
+        self.field_pattern = r"temp=(?P<temp>[\d\.]+)\s+humidity=(?P<humidity>[\d\.]+)"
+
+    def test_basic_parsing(self):
+        """Test standard parsing extracting data_id and timestamp from record."""
+        parser = RegexParser(field_patterns=[self.field_pattern])
+        result = parser.parse_record(self.sample_record)
+
+        self.assertEqual(result['data_id'], 'sensor1')
+        self.assertEqual(result['timestamp'], 1672574400.0)
+        self.assertEqual(result['fields']['temp'], '23.5')
+        self.assertEqual(result['fields']['humidity'], '60')
+
+    def test_data_id_override(self):
+        """Test that passing data_id to __init__ overrides the record's data_id."""
+        # Record says 'sensor1', but we initialize with 'override_id'
+        parser = RegexParser(field_patterns=[self.field_pattern], data_id='override_id')
+        result = parser.parse_record(self.sample_record)
+
+        self.assertEqual(result['data_id'], 'override_id')
+
+    def test_data_id_fallback(self):
+        """Test that data_id arg fills in when record has no data_id."""
+        # Using a format that doesn't look for data_id at the start
+        # e.g., just timestamp and fields
+        record_format = r"(?P<timestamp>[0-9TZ:\-\.]*)\s+(?P<field_string>.*)"
+        parser = RegexParser(record_format=record_format, data_id='fixed_id')
+
+        result = parser.parse_record(self.no_id_record)
+        self.assertEqual(result['data_id'], 'fixed_id')
+
+    def test_unknown_data_id(self):
+        """Test default 'unknown' if no data_id in record and no override provided."""
+        record_format = r"(?P<timestamp>[0-9TZ:\-\.]*)\s+(?P<field_string>.*)"
+        parser = RegexParser(record_format=record_format)  # No data_id arg
+
+        result = parser.parse_record(self.no_id_record)
+        self.assertEqual(result['data_id'], 'unknown')
+
+    def test_return_das_record(self):
+        """Test returning a DASRecord object."""
+        parser = RegexParser(field_patterns=[self.field_pattern], return_das_record=True)
+        result = parser.parse_record(self.sample_record)
+
+        self.assertIsInstance(result, DASRecord)
+        self.assertEqual(result.data_id, 'sensor1')
+        self.assertEqual(result.fields['temp'], '23.5')
+
+    def test_return_json(self):
+        """Test returning a JSON string."""
+        parser = RegexParser(field_patterns=[self.field_pattern], return_json=True)
+        result = parser.parse_record(self.sample_record)
+
+        self.assertIsInstance(result, str)
+        parsed_json = json.loads(result)
+        self.assertEqual(parsed_json['data_id'], 'sensor1')
+        self.assertEqual(parsed_json['fields']['temp'], '23.5')
+
+    def test_message_type_dict(self):
+        """Test using a dictionary of message types for field patterns."""
+        patterns = {
+            'weather': r"temp=(?P<temp>[\d\.]+)",
+            'nav': r"lat=(?P<lat>[\d\.]+)"
+        }
+        parser = RegexParser(field_patterns=patterns)
+
+        # Test matching first pattern
+        rec1 = "sensor1 2023-01-01T12:00:00Z temp=23.5"
+        res1 = parser.parse_record(rec1)
+        self.assertEqual(res1['fields']['temp'], '23.5')
+
+        # Test matching second pattern
+        rec2 = "sensor1 2023-01-01T12:00:00Z lat=45.0"
+        res2 = parser.parse_record(rec2)
+        self.assertEqual(res2['fields']['lat'], '45.0')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/logger/utils/test_regex_parser.py
+++ b/test/logger/utils/test_regex_parser.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import unittest
-import json
 import sys
 from os.path import dirname, realpath
 
@@ -27,10 +26,11 @@ class TestRegexParser(unittest.TestCase):
         parser = RegexParser(field_patterns=[self.field_pattern])
         result = parser.parse_record(self.sample_record)
 
-        self.assertEqual(result['data_id'], 'sensor1')
-        self.assertEqual(result['timestamp'], 1672574400.0)
-        self.assertEqual(result['fields']['temp'], '23.5')
-        self.assertEqual(result['fields']['humidity'], '60')
+        self.assertIsInstance(result, DASRecord)
+        self.assertEqual(result.data_id, 'sensor1')
+        self.assertEqual(result.timestamp, 1672574400.0)
+        self.assertEqual(result.fields['temp'], '23.5')
+        self.assertEqual(result.fields['humidity'], '60')
 
     def test_data_id_override(self):
         """Test that passing data_id to __init__ overrides the record's data_id."""
@@ -38,7 +38,7 @@ class TestRegexParser(unittest.TestCase):
         parser = RegexParser(field_patterns=[self.field_pattern], data_id='override_id')
         result = parser.parse_record(self.sample_record)
 
-        self.assertEqual(result['data_id'], 'override_id')
+        self.assertEqual(result.data_id, 'override_id')
 
     def test_data_id_fallback(self):
         """Test that data_id arg fills in when record has no data_id."""
@@ -48,7 +48,7 @@ class TestRegexParser(unittest.TestCase):
         parser = RegexParser(record_format=record_format, data_id='fixed_id')
 
         result = parser.parse_record(self.no_id_record)
-        self.assertEqual(result['data_id'], 'fixed_id')
+        self.assertEqual(result.data_id, 'fixed_id')
 
     def test_unknown_data_id(self):
         """Test default 'unknown' if no data_id in record and no override provided."""
@@ -56,26 +56,7 @@ class TestRegexParser(unittest.TestCase):
         parser = RegexParser(record_format=record_format)  # No data_id arg
 
         result = parser.parse_record(self.no_id_record)
-        self.assertEqual(result['data_id'], 'unknown')
-
-    def test_return_das_record(self):
-        """Test returning a DASRecord object."""
-        parser = RegexParser(field_patterns=[self.field_pattern], return_das_record=True)
-        result = parser.parse_record(self.sample_record)
-
-        self.assertIsInstance(result, DASRecord)
-        self.assertEqual(result.data_id, 'sensor1')
-        self.assertEqual(result.fields['temp'], '23.5')
-
-    def test_return_json(self):
-        """Test returning a JSON string."""
-        parser = RegexParser(field_patterns=[self.field_pattern], return_json=True)
-        result = parser.parse_record(self.sample_record)
-
-        self.assertIsInstance(result, str)
-        parsed_json = json.loads(result)
-        self.assertEqual(parsed_json['data_id'], 'sensor1')
-        self.assertEqual(parsed_json['fields']['temp'], '23.5')
+        self.assertEqual(result.data_id, 'unknown')
 
     def test_message_type_dict(self):
         """Test using a dictionary of message types for field patterns."""
@@ -88,12 +69,12 @@ class TestRegexParser(unittest.TestCase):
         # Test matching first pattern
         rec1 = "sensor1 2023-01-01T12:00:00Z temp=23.5"
         res1 = parser.parse_record(rec1)
-        self.assertEqual(res1['fields']['temp'], '23.5')
+        self.assertEqual(res1.fields['temp'], '23.5')
 
         # Test matching second pattern
         rec2 = "sensor1 2023-01-01T12:00:00Z lat=45.0"
         res2 = parser.parse_record(rec2)
-        self.assertEqual(res2['fields']['lat'], '45.0')
+        self.assertEqual(res2.fields['lat'], '45.0')
 
 
 if __name__ == '__main__':

--- a/test/logger/utils/test_regex_parser.py
+++ b/test/logger/utils/test_regex_parser.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import unittest
+import json
+import sys
+from os.path import dirname, realpath
+
+# Add the proper path so imports work as if running in the package structure
+# path: test/logger/utils/test_regex_parser.py -> root (4 levels up)
+sys.path.append(dirname(dirname(dirname(dirname(realpath(__file__))))))
+
+from logger.utils.regex_parser import RegexParser  # noqa: E402
+from logger.utils.das_record import DASRecord  # noqa: E402
+
+
+class TestRegexParser(unittest.TestCase):
+
+    def setUp(self):
+        # A simple record: data_id timestamp field_string
+        self.sample_record = "sensor1 2023-01-01T12:00:00.000Z temp=23.5 humidity=60"
+        self.no_id_record = "2023-01-01T12:00:00.000Z temp=23.5"
+
+        # A pattern to extract fields
+        self.field_pattern = r"temp=(?P<temp>[\d\.]+)\s+humidity=(?P<humidity>[\d\.]+)"
+
+    def test_basic_parsing(self):
+        """Test standard parsing extracting data_id and timestamp from record."""
+        parser = RegexParser(field_patterns=[self.field_pattern])
+        result = parser.parse_record(self.sample_record)
+
+        self.assertEqual(result['data_id'], 'sensor1')
+        self.assertEqual(result['timestamp'], 1672574400.0)
+        self.assertEqual(result['fields']['temp'], '23.5')
+        self.assertEqual(result['fields']['humidity'], '60')
+
+    def test_data_id_override(self):
+        """Test that passing data_id to __init__ overrides the record's data_id."""
+        # Record says 'sensor1', but we initialize with 'override_id'
+        parser = RegexParser(field_patterns=[self.field_pattern], data_id='override_id')
+        result = parser.parse_record(self.sample_record)
+
+        self.assertEqual(result['data_id'], 'override_id')
+
+    def test_data_id_fallback(self):
+        """Test that data_id arg fills in when record has no data_id."""
+        # Using a format that doesn't look for data_id at the start
+        # e.g., just timestamp and fields
+        record_format = r"(?P<timestamp>[0-9TZ:\-\.]*)\s+(?P<field_string>.*)"
+        parser = RegexParser(record_format=record_format, data_id='fixed_id')
+
+        result = parser.parse_record(self.no_id_record)
+        self.assertEqual(result['data_id'], 'fixed_id')
+
+    def test_unknown_data_id(self):
+        """Test default 'unknown' if no data_id in record and no override provided."""
+        record_format = r"(?P<timestamp>[0-9TZ:\-\.]*)\s+(?P<field_string>.*)"
+        parser = RegexParser(record_format=record_format)  # No data_id arg
+
+        result = parser.parse_record(self.no_id_record)
+        self.assertEqual(result['data_id'], 'unknown')
+
+    def test_return_das_record(self):
+        """Test returning a DASRecord object."""
+        parser = RegexParser(field_patterns=[self.field_pattern], return_das_record=True)
+        result = parser.parse_record(self.sample_record)
+
+        self.assertIsInstance(result, DASRecord)
+        self.assertEqual(result.data_id, 'sensor1')
+        self.assertEqual(result.fields['temp'], '23.5')
+
+    def test_return_json(self):
+        """Test returning a JSON string."""
+        parser = RegexParser(field_patterns=[self.field_pattern], return_json=True)
+        result = parser.parse_record(self.sample_record)
+
+        self.assertIsInstance(result, str)
+        parsed_json = json.loads(result)
+        self.assertEqual(parsed_json['data_id'], 'sensor1')
+        self.assertEqual(parsed_json['fields']['temp'], '23.5')
+
+    def test_message_type_dict(self):
+        """Test using a dictionary of message types for field patterns."""
+        patterns = {
+            'weather': r"temp=(?P<temp>[\d\.]+)",
+            'nav': r"lat=(?P<lat>[\d\.]+)"
+        }
+        parser = RegexParser(field_patterns=patterns)
+
+        # Test matching first pattern
+        rec1 = "sensor1 2023-01-01T12:00:00Z temp=23.5"
+        res1 = parser.parse_record(rec1)
+        self.assertEqual(res1['fields']['temp'], '23.5')
+
+        # Test matching second pattern
+        rec2 = "sensor1 2023-01-01T12:00:00Z lat=45.0"
+        res2 = parser.parse_record(rec2)
+        self.assertEqual(res2['fields']['lat'], '45.0')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a first pass at a RegexParseTransform that unifies the functionality of CORIOLIX and CSIRO transforms (#507 ).

For simplicity, at the moment it doesn't try to perfectly mimic the calling conventions of either, though that could be done at the cost of a little complexity at initialization.

I'd love to get everyones' thoughts on this direction before adding it to the dev branch.