### PR TITLE
Add NMEA timestamp extraction to TimestampTransform

### DIFF
--- a/logger/transforms/timestamp_transform.py
+++ b/logger/transforms/timestamp_transform.py
@@ -1,32 +1,96 @@
 #!/usr/bin/env python3
 
+import logging
 import sys
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
 from logger.utils import timestamp  # noqa: E402
+from logger.utils.nmea_timestamp import NMEATimestampExtractor  # noqa: E402
 from logger.transforms.transform import Transform  # noqa: E402
 
 
 ################################################################################
 class TimestampTransform(Transform):
-    """Prepend a timestamp to a text record."""
+    """Prepend a timestamp to a text record.
+
+    By default the system clock is used.  When ``use_nmea_timestamp`` is
+    enabled, the transform first attempts to extract the timestamp
+    embedded in NMEA 0183 sentences (GGA, RMC, ZDA, and many others)
+    and only falls back to the system clock when no NMEA time is
+    available.
+
+    Parameters
+    ----------
+    time_format : str
+        strftime format string for the prepended timestamp.  Defaults
+        to ``logger.utils.timestamp.TIME_FORMAT``
+        (``'%Y-%m-%dT%H:%M:%S.%fZ'``).
+    time_zone : datetime.timezone
+        Timezone applied to the timestamp.  Defaults to UTC.
+    sep : str
+        Separator inserted between the timestamp and the record text.
+        Defaults to a single space.
+
+    use_nmea_timestamp : bool
+        When True, attempt to parse the NMEA time field from the
+        incoming record before falling back to the system clock.
+        Defaults to False.
+    nmea_timestamp_timeout : float
+        How many seconds a previously-extracted NMEA timestamp remains
+        valid for records that do not carry their own time field
+        (e.g. VTG, HDT).  After this period the system clock is used
+        instead.  Defaults to 1 s.
+    nmea_time_drift_threshold : float or None
+        If the absolute difference between the NMEA-derived time and
+        the system clock exceeds this value (in seconds), a warning is
+        logged.  Set to None to disable the check.  Defaults to 0.1 s.
+    quiet : bool
+        Inherited from Transform (passed via ``**kwargs``).  When True,
+        suppresses all warnings from both the transform and the
+        underlying NMEATimestampExtractor (drift, staleness, and
+        fallback warnings).  Defaults to False.
+    """
     def __init__(self, time_format=timestamp.TIME_FORMAT,
-                 time_zone=timestamp.timezone.utc, sep=' ', **kwargs):
-        """If timestamp_format is not specified, use default format"""
+                 time_zone=timestamp.timezone.utc, sep=' ',
+                 use_nmea_timestamp=False,
+                 nmea_timestamp_timeout=1,
+                 nmea_time_drift_threshold=0.1, **kwargs):
+        """Create a TimestampTransform."""
         super().__init__(**kwargs)  # processes 'quiet' and type hints
 
         self.time_format = time_format
         self.time_zone = time_zone
         self.sep = sep
+        self.use_nmea_timestamp = use_nmea_timestamp
+        self.nmea_extractor = None
+        if use_nmea_timestamp:
+            self.nmea_extractor = NMEATimestampExtractor(
+                timeout=nmea_timestamp_timeout,
+                quiet=self.quiet,
+                time_drift_threshold=nmea_time_drift_threshold)
 
     ############################
     def transform(self, record: str, ts=None) -> str:
         """Prepend a timestamp"""
 
-        # First off, grab a current timestamp
-        ts = ts or timestamp.time_str(time_format=self.time_format,
-                                      time_zone=self.time_zone)
+        # If they've not given us a timestamp, find one.
+        if ts is None:
+            if self.nmea_extractor is None:
+                # Things are simple if we're not trying to extract a timestamp from NMEA.
+                ts = timestamp.time_str(time_format=self.time_format,
+                                        time_zone=self.time_zone)
+            else:
+                # If we're going to try to extract ts from NMEA
+                ts = self.nmea_extractor.get_timestamp(
+                    record, self.time_format, self.time_zone)
+                # Failed, so fall back to system time.
+                if ts is None and not self.quiet:
+                    logging.warning(
+                        'TimestampTransform: no NMEA timestamp for record, '
+                        'falling back to system time')
+                ts = ts or timestamp.time_str(time_format=self.time_format,
+                                              time_zone=self.time_zone)
 
         # See if it's something we can process, and if not, try digesting
         if not self.can_process_record(record):  # inherited from BaseModule()

--- a/logger/utils/nmea_timestamp.py
+++ b/logger/utils/nmea_timestamp.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Extract timestamps from NMEA sentences.
+
+Supports all common NMEA 0183 sentence types that include timestamps,
+both standard and proprietary. Tracks the most recent NMEA-derived
+timestamp so that non-timestamped sentences (e.g. VTG, HDT) can reuse
+it, subject to a configurable staleness timeout.
+
+Supported standard sentences:
+    GGA, GLL, RMC, ZDA, GBS, GST, GNS, BWC, TLL, TTM
+
+Supported proprietary sentences:
+    PASHR, PGRMF, PTNL GGK/PJK, PUBX 00/04, PSIMSNS, PSIMSSB, PSXN 26
+"""
+
+import logging
+import re
+import time
+from datetime import datetime, timezone
+
+from logger.utils import timestamp as ts_util
+
+# Captures the full sentence identifier between $/! and the first comma.
+# Works for both standard (e.g. "GPGGA") and proprietary (e.g. "PSIMSNS").
+NMEA_PREFIX_RE = re.compile(r'^[$!](\w+),')
+
+# NMEA time field: hhmmss or hhmmss.ss(s).
+# No end-of-string anchor so it tolerates residual checksum characters.
+NMEA_TIME_RE = re.compile(r'^(\d{2})(\d{2})(\d{2}(?:\.\d+)?)')
+
+# ---------------------------------------------------------------------------
+# Sentence lookup tables
+#
+# Standard sentences are identified by the last 3 characters of a 5-char
+# talker+type prefix (e.g. "GPGGA" -> "GGA").  Proprietary sentences are
+# identified by their full prefix or by prefix + sub-type field.
+#
+# Values are the comma-split field index of the time (hhmmss.ss) field.
+# ---------------------------------------------------------------------------
+
+# Standard NMEA sentences: 3-char type -> time field index
+_STD_TIME = {
+    'GGA': 1, 'GLL': 5, 'RMC': 1, 'ZDA': 1,
+    'GBS': 1, 'GST': 1, 'GNS': 1, 'BWC': 1,
+    'TLL': 7, 'TTM': 14,
+}
+
+# Standard sentences carrying a ddmmyy date: type -> date field index
+_STD_DATE = {'RMC': 9}
+
+# ZDA carries day/month/year in separate fields
+_ZDA_DATE_FIELDS = (2, 3, 4)  # (day_idx, month_idx, year_idx)
+
+# 5-char proprietary sentences (matched by full prefix without $)
+_PROP5_TIME = {'PASHR': 1, 'PGRMF': 4}
+_PROP5_DATE = {'PGRMF': 3}
+
+# Sub-typed proprietary: (prefix, first-data-field) -> time field index
+_SUB_TIME = {
+    ('PTNL', 'GGK'): 2, ('PTNL', 'PJK'): 2,
+    ('PUBX', '00'): 2, ('PUBX', '04'): 2,
+}
+_SUB_DATE = {
+    ('PTNL', 'GGK'): 3, ('PTNL', 'PJK'): 3,
+    ('PUBX', '04'): 3,
+}
+
+# Long-name proprietary (>5 chars): full prefix -> time field index
+_LONG_TIME = {'PSIMSNS': 1, 'PSIMSSB': 6}
+
+
+def _strip_checksum(field):
+    """Remove ``*checksum`` suffix from a field value."""
+    idx = field.find('*')
+    return field[:idx] if idx >= 0 else field
+
+
+class NMEATimestampExtractor:
+    """Parse NMEA sentences to extract embedded timestamps."""
+
+    def __init__(self, timeout=1, quiet=False, time_drift_threshold=0.1):
+        self.timeout = timeout
+        self.quiet = quiet
+        self.time_drift_threshold = time_drift_threshold
+        self.last_nmea_date = None      # datetime.date from RMC/ZDA/etc.
+        self.last_nmea_datetime = None   # full datetime object
+        self.last_nmea_system_time = 0   # time.time() of last extraction
+        self.seen_timestamp = False
+
+    def get_timestamp(self, record, time_format=ts_util.TIME_FORMAT,
+                      time_zone=ts_util.timezone.utc):
+        """Return a formatted timestamp string extracted from *record*,
+        or fall back to the last observed NMEA timestamp. Returns None
+        when no NMEA timestamp is available (caller should use system time).
+        """
+        if not isinstance(record, str):
+            return None
+
+        nmea_dt = self._parse_nmea_datetime(record)
+        if nmea_dt is not None:
+            now = time.time()
+            self.last_nmea_datetime = nmea_dt
+            self.last_nmea_system_time = now
+            self.seen_timestamp = True
+            if not self.quiet and self.time_drift_threshold is not None:
+                nmea_epoch = nmea_dt.timestamp()
+                drift = abs(nmea_epoch - now)
+                if drift > self.time_drift_threshold:
+                    logging.warning(
+                        'NMEATimestampExtractor: NMEA time differs from '
+                        'system time by %.3fs (threshold=%.3fs)',
+                        drift, self.time_drift_threshold)
+            return nmea_dt.strftime(time_format)
+
+        # Fall back to last observed timestamp
+        if not self.seen_timestamp:
+            return None
+
+        elapsed = time.time() - self.last_nmea_system_time
+        if elapsed > self.timeout:
+            if not self.quiet:
+                logging.warning(
+                    'NMEATimestampExtractor: last NMEA timestamp is %.1fs '
+                    'old (timeout=%s); falling back to system time',
+                    elapsed, self.timeout)
+            return None
+
+        return self.last_nmea_datetime.strftime(time_format)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _parse_nmea_datetime(self, record):
+        """Try to extract a datetime from an NMEA sentence.
+        Returns a datetime object or None.
+        """
+        m = NMEA_PREFIX_RE.match(record)
+        if not m:
+            return None
+
+        prefix = m.group(1).upper()
+        fields = record.split(',')
+
+        # 1. Standard 5-char prefix (2-char talker + 3-char type)
+        #    and 5-char proprietary (e.g. PASHR, PGRMF)
+        if len(prefix) == 5:
+            stype = prefix[2:]
+            if stype in _STD_TIME:
+                return self._extract_standard(stype, fields)
+            if prefix in _PROP5_TIME:
+                return self._extract_prop5(prefix, fields)
+
+        # 2. Sub-typed proprietary (prefix + first data field)
+        if len(fields) > 1:
+            sub = _strip_checksum(fields[1]).strip().upper()
+            subkey = (prefix, sub)
+            if subkey == ('PSXN', '26'):
+                return self._extract_psxn26(fields)
+            if subkey in _SUB_TIME:
+                return self._extract_subtype(subkey, fields)
+
+        # 3. Long-name proprietary (>5 chars)
+        if prefix in _LONG_TIME:
+            return self._extract_long(prefix, fields)
+
+        return None
+
+    # -- Extraction helpers ------------------------------------------------
+
+    def _extract_standard(self, stype, fields):
+        """Extract datetime from a standard NMEA sentence."""
+        time_idx = _STD_TIME[stype]
+        date = None
+        if stype == 'ZDA':
+            day_i, month_i, year_i = _ZDA_DATE_FIELDS
+            date = self._parse_zda_date(
+                self._get_field(fields, day_i),
+                self._get_field(fields, month_i),
+                self._get_field(fields, year_i))
+        elif stype in _STD_DATE:
+            date = self._parse_ddmmyy(
+                self._get_field(fields, _STD_DATE[stype]))
+        return self._datetime_from_time_field(
+            self._get_field(fields, time_idx), date=date)
+
+    def _extract_prop5(self, prefix, fields):
+        """Extract datetime from a 5-char proprietary sentence."""
+        time_idx = _PROP5_TIME[prefix]
+        date = None
+        if prefix in _PROP5_DATE:
+            date = self._parse_ddmmyy(
+                self._get_field(fields, _PROP5_DATE[prefix]))
+        return self._datetime_from_time_field(
+            self._get_field(fields, time_idx), date=date)
+
+    def _extract_subtype(self, subkey, fields):
+        """Extract datetime from a sub-typed proprietary sentence."""
+        time_idx = _SUB_TIME[subkey]
+        date = None
+        if subkey in _SUB_DATE:
+            date = self._parse_ddmmyy(
+                self._get_field(fields, _SUB_DATE[subkey]))
+        return self._datetime_from_time_field(
+            self._get_field(fields, time_idx), date=date)
+
+    def _extract_long(self, prefix, fields):
+        """Extract datetime from a long-name proprietary sentence."""
+        time_idx = _LONG_TIME[prefix]
+        return self._datetime_from_time_field(
+            self._get_field(fields, time_idx))
+
+    def _extract_psxn26(self, fields):
+        """Extract datetime from PSXN,26 (separate Y/M/D/H/M/S fields)."""
+        try:
+            year = int(self._get_field(fields, 2))
+            month = int(self._get_field(fields, 3))
+            day = int(self._get_field(fields, 4))
+            hour = int(self._get_field(fields, 5))
+            minute = int(self._get_field(fields, 6))
+            sec_str = self._get_field(fields, 7)
+            second_frac = float(sec_str)
+            second = int(second_frac)
+            microsecond = int((second_frac - second) * 1_000_000)
+            date = datetime(year, month, day, tzinfo=timezone.utc).date()
+            self.last_nmea_date = date
+            return datetime(
+                year=year, month=month, day=day,
+                hour=hour, minute=minute, second=second,
+                microsecond=microsecond, tzinfo=timezone.utc)
+        except (ValueError, IndexError):
+            return None
+
+    # -- Field access and parsing ------------------------------------------
+
+    @staticmethod
+    def _get_field(fields, idx):
+        """Safely get a comma-split field, stripping any checksum suffix."""
+        if idx < len(fields):
+            return _strip_checksum(fields[idx].strip())
+        return ''
+
+    def _datetime_from_time_field(self, time_field, date=None):
+        """Parse an NMEA time field (hhmmss.ss) and combine with a date.
+        If *date* is provided, also update ``self.last_nmea_date``.
+        """
+        m = NMEA_TIME_RE.match(time_field)
+        if not m:
+            return None
+
+        hour = int(m.group(1))
+        minute = int(m.group(2))
+        second_frac = float(m.group(3))
+        second = int(second_frac)
+        microsecond = int((second_frac - second) * 1_000_000)
+
+        if date is not None:
+            self.last_nmea_date = date
+        use_date = self.last_nmea_date
+        if use_date is None:
+            use_date = datetime.now(timezone.utc).date()
+
+        return datetime(
+            year=use_date.year, month=use_date.month, day=use_date.day,
+            hour=hour, minute=minute, second=second,
+            microsecond=microsecond, tzinfo=timezone.utc,
+        )
+
+    @staticmethod
+    def _parse_ddmmyy(date_field):
+        """Parse a ``ddmmyy`` date string (used by RMC, PGRMF, etc.)."""
+        if not date_field or len(date_field) < 6:
+            return None
+        try:
+            day = int(date_field[0:2])
+            month = int(date_field[2:4])
+            year = int(date_field[4:6])
+            year += 2000 if year < 80 else 1900
+            return datetime(year, month, day, tzinfo=timezone.utc).date()
+        except (ValueError, IndexError):
+            return None
+
+    @staticmethod
+    def _parse_zda_date(day_field, month_field, year_field):
+        """Parse day, month, year fields from a ZDA sentence."""
+        try:
+            day = int(day_field)
+            month = int(month_field)
+            year = int(year_field)
+            return datetime(year, month, day, tzinfo=timezone.utc).date()
+        except (ValueError, IndexError):
+            return None

--- a/test/logger/transforms/test_timestamp_transform.py
+++ b/test/logger/transforms/test_timestamp_transform.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import time
 import unittest
 
 sys.path.append('.')
@@ -56,6 +57,107 @@ class TestTimestampTransform(unittest.TestCase):
         today = timestamp.date_str()
         self.assertEqual(result.split()[0], today)
         self.assertEqual(result.split()[1], 'blah')
+
+
+class TestTimestampTransformNMEA(unittest.TestCase):
+    """Tests for use_nmea_timestamp=True."""
+
+    def test_gga_timestamp(self):
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        record = '$GPGGA,123456.00,4807.038,N,01131.000,E,1,08,0.9,545.4,M,,,,*47'
+        result = transform.transform(record)
+        self.assertIn('12:34:56', result)
+        self.assertTrue(result.endswith(record))
+
+    def test_rmc_timestamp(self):
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        record = ('$GPRMC,083559.00,A,4717.115,N,00833.912,E,'
+                  '0.0,0.0,130723,,,A*xx')
+        result = transform.transform(record)
+        self.assertIn('2023-07-13', result)
+        self.assertIn('08:35:59', result)
+
+    def test_zda_timestamp(self):
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        record = '$GPZDA,160012.71,11,03,2025,00,00*6C'
+        result = transform.transform(record)
+        self.assertIn('2025-03-11', result)
+        self.assertIn('16:00:12', result)
+
+    def test_gll_timestamp(self):
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        record = '$GPGLL,4916.45,N,12311.12,W,225444.00,A,*xx'
+        result = transform.transform(record)
+        self.assertIn('22:54:44', result)
+
+    def test_vtg_falls_back_to_last_nmea(self):
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        gga = '$GPGGA,140000.00,,,,,,,,,,,,,*xx'
+        transform.transform(gga)
+
+        vtg = '$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*xx'
+        result = transform.transform(vtg)
+        self.assertIn('14:00:00', result)
+        self.assertTrue(result.endswith(vtg))
+
+    def test_no_nmea_seen_falls_back_to_system_time(self):
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        vtg = '$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*xx'
+        result = transform.transform(vtg)
+        # Should get a system timestamp (approximately now)
+        ts_str = result.split(' ', 1)[0]
+        ts_val = timestamp.timestamp(time_str=ts_str)
+        self.assertAlmostEqual(ts_val, timestamp.timestamp(), places=1)
+
+    def test_staleness_falls_back_to_system_time(self):
+        transform = TimestampTransform(
+            use_nmea_timestamp=True, nmea_timestamp_timeout=2)
+        gga = '$GPGGA,140000.00,,,,,,,,,,,,,*xx'
+        transform.transform(gga)
+
+        # Simulate stale timestamp
+        transform.nmea_extractor.last_nmea_system_time = time.time() - 10
+
+        vtg = '$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*xx'
+        result = transform.transform(vtg)
+        ts_str = result.split(' ', 1)[0]
+        ts_val = timestamp.timestamp(time_str=ts_str)
+        self.assertAlmostEqual(ts_val, timestamp.timestamp(), places=1)
+
+    def test_disabled_by_default(self):
+        """Without use_nmea_timestamp, GGA gets system time, not NMEA time."""
+        transform = TimestampTransform()
+        record = '$GPGGA,000000.00,,,,,,,,,,,,,*xx'
+        result = transform.transform(record)
+        ts_str = result.split(' ', 1)[0]
+        ts_val = timestamp.timestamp(time_str=ts_str)
+        now = timestamp.timestamp()
+        self.assertAlmostEqual(ts_val, now, places=1)
+
+    def test_pashr_timestamp(self):
+        """Proprietary PASHR sentence should extract NMEA time."""
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        record = ('$PASHR,113000.00,123.4,T,1.2,-0.5,'
+                  '0.3,0.1,0.1,0.2,1,0*xx')
+        result = transform.transform(record)
+        self.assertIn('11:30:00', result)
+        self.assertTrue(result.endswith(record))
+
+    def test_psxn26_timestamp(self):
+        """PSXN,26 with separate Y/M/D/H/M/S fields."""
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        record = '$PSXN,26,2025,03,15,09,15,00.50*xx'
+        result = transform.transform(record)
+        self.assertIn('2025-03-15', result)
+        self.assertIn('09:15:00', result)
+
+    def test_gbs_timestamp(self):
+        """Standard GBS sentence should extract NMEA time."""
+        transform = TimestampTransform(use_nmea_timestamp=True)
+        record = '$GPGBS,091500.00,1.2,3.4,5.6,7,,1.8,2.3*xx'
+        result = transform.transform(record)
+        self.assertIn('09:15:00', result)
+        self.assertTrue(result.endswith(record))
 
 
 if __name__ == '__main__':

--- a/test/logger/utils/test_nmea_timestamp.py
+++ b/test/logger/utils/test_nmea_timestamp.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Unit tests for NMEATimestampExtractor."""
+
+import sys
+import time
+import unittest
+from datetime import datetime, timezone
+
+sys.path.append('.')
+from logger.utils.nmea_timestamp import NMEATimestampExtractor  # noqa: E402
+
+
+class TestNMEATimestampExtractor(unittest.TestCase):
+
+    def setUp(self):
+        self.extractor = NMEATimestampExtractor(timeout=5)
+
+    # ----- GGA -----
+    def test_gga(self):
+        record = ('$GPGGA,123456.00,4807.038,N,01131.000,E,'
+                  '1,08,0.9,545.4,M,,,,*47')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('12:34:56', result)
+
+    def test_gga_different_talker(self):
+        record = '$INGGA,091500.50,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('09:15:00', result)
+
+    # ----- GLL -----
+    def test_gll(self):
+        record = '$GPGLL,4916.45,N,12311.12,W,225444.00,A,*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('22:54:44', result)
+
+    # ----- RMC -----
+    def test_rmc_with_date(self):
+        record = ('$GPRMC,083559.00,A,4717.115,N,00833.912,E,'
+                  '0.0,0.0,130723,,,A*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('2023-07-13', result)
+        self.assertIn('08:35:59', result)
+
+    def test_rmc_sets_date_for_subsequent(self):
+        """RMC date should be reused by later GGA sentences."""
+        rmc = '$GPRMC,120000.00,A,,,,,,,150125,,,A*xx'
+        self.extractor.get_timestamp(rmc)
+
+        gga = '$GPGGA,120001.00,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(gga)
+        self.assertIn('2025-01-15', result)
+        self.assertIn('12:00:01', result)
+
+    # ----- ZDA -----
+    def test_zda(self):
+        record = '$GPZDA,160012.71,11,03,2025,00,00*6C'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('2025-03-11', result)
+        self.assertIn('16:00:12', result)
+
+    def test_zda_sets_date_for_subsequent(self):
+        zda = '$GPZDA,100000.00,25,12,2024,00,00*xx'
+        self.extractor.get_timestamp(zda)
+
+        gga = '$GPGGA,100001.00,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(gga)
+        self.assertIn('2024-12-25', result)
+
+    # ----- GBS -----
+    def test_gbs(self):
+        record = '$GPGBS,091500.00,1.2,3.4,5.6,7,,1.8,2.3*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('09:15:00', result)
+
+    # ----- GST -----
+    def test_gst(self):
+        record = '$GPGST,140030.00,1.2,3.4,5.6,7.8,9.0,1.2,3.4*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('14:00:30', result)
+
+    # ----- GNS -----
+    def test_gns(self):
+        record = ('$GNGNS,103000.00,4807.038,N,01131.000,E,'
+                  'AN,08,0.9,545.4,47.0,,*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('10:30:00', result)
+
+    # ----- BWC -----
+    def test_bwc(self):
+        record = ('$GPBWC,220000.00,4807.038,N,01131.000,E,'
+                  '123.4,T,234.5,M,12.3,N,DEST,A*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('22:00:00', result)
+
+    # ----- TLL -----
+    def test_tll(self):
+        record = ('$RATLL,01,4807.038,N,01131.000,E,'
+                  'TARGET,185500.00,T,R*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('18:55:00', result)
+
+    # ----- TTM -----
+    def test_ttm(self):
+        record = ('$RATTM,01,1.23,45.6,T,7.8,90.1,T,2.3,4.5,N,'
+                  'TARGET,T,R,061530.00,A*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('06:15:30', result)
+
+    # ----- PASHR -----
+    def test_pashr(self):
+        record = '$PASHR,113000.00,123.4,T,1.2,-0.5,0.3,0.1,0.1,0.2,1,0*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('11:30:00', result)
+
+    # ----- PGRMF -----
+    def test_pgrmf(self):
+        record = ('$PGRMF,1234,567890.0,130723,091500,18,'
+                  '4807.038,N,01131.000,E,A,3,12.3,45.6,1.2,3.4*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('2023-07-13', result)
+        self.assertIn('09:15:00', result)
+
+    # ----- PTNL,GGK -----
+    def test_ptnl_ggk(self):
+        record = ('$PTNL,GGK,091500.00,130723,'
+                  '4807.038,N,01131.000,E,1,08,1.2,45.6*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('2023-07-13', result)
+        self.assertIn('09:15:00', result)
+
+    # ----- PTNL,PJK -----
+    def test_ptnl_pjk(self):
+        record = ('$PTNL,PJK,140000.00,250125,'
+                  '1234.5,N,6789.0,E,1,08,1.2,45.6*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('2025-01-25', result)
+        self.assertIn('14:00:00', result)
+
+    # ----- PUBX,00 -----
+    def test_pubx00(self):
+        record = ('$PUBX,00,170000.00,4807.038,N,01131.000,E,'
+                  '545.4,G3,1.2,3.4,0.5,180.0,-0.1,2.3,8,0,0*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('17:00:00', result)
+
+    # ----- PUBX,04 -----
+    def test_pubx04(self):
+        record = ('$PUBX,04,091500.00,130723,'
+                  '091500.00,130723,0.0,1234.5,6.7,20.0*xx')
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('2023-07-13', result)
+        self.assertIn('09:15:00', result)
+
+    # ----- PSIMSNS -----
+    def test_psimsns(self):
+        record = '$PSIMSNS,091500.00,1.2,-0.5,123.4*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('09:15:00', result)
+
+    # ----- PSIMSSB -----
+    def test_psimssb(self):
+        """Time is the last data field; checksum must be stripped."""
+        record = '$PSIMSSB,TRANS1,59.123,5.456,100.5,2.3,091500.00*5C'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('09:15:00', result)
+
+    # ----- PSXN,26 -----
+    def test_psxn26(self):
+        record = '$PSXN,26,2025,03,15,09,15,00.50*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('2025-03-15', result)
+        self.assertIn('09:15:00', result)
+
+    def test_psxn26_sets_date(self):
+        """PSXN,26 should set date for subsequent time-only sentences."""
+        psxn = '$PSXN,26,2024,06,20,12,00,00.00*xx'
+        self.extractor.get_timestamp(psxn)
+
+        gga = '$GPGGA,120001.00,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(gga)
+        self.assertIn('2024-06-20', result)
+        self.assertIn('12:00:01', result)
+
+    # ----- Fallback to last observed timestamp -----
+    def test_fallback_vtg(self):
+        """VTG has no timestamp; should reuse last observed."""
+        gga = '$GPGGA,140000.00,,,,,,,,,,,,,*xx'
+        self.extractor.get_timestamp(gga)
+
+        vtg = '$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*xx'
+        result = self.extractor.get_timestamp(vtg)
+        self.assertIn('14:00:00', result)
+
+    # ----- No timestamp ever seen -----
+    def test_no_timestamp_seen_returns_none(self):
+        vtg = '$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*xx'
+        result = self.extractor.get_timestamp(vtg)
+        self.assertIsNone(result)
+
+    # ----- Non-NMEA record -----
+    def test_non_nmea_no_timestamp_seen(self):
+        result = self.extractor.get_timestamp('just some text')
+        self.assertIsNone(result)
+
+    def test_non_nmea_after_timestamp(self):
+        """Non-NMEA text should still get fallback timestamp if available."""
+        gga = '$GPGGA,080000.00,,,,,,,,,,,,,*xx'
+        self.extractor.get_timestamp(gga)
+        result = self.extractor.get_timestamp('plain text')
+        # Falls back to last observed NMEA timestamp
+        self.assertIn('08:00:00', result)
+
+    # ----- Non-string record -----
+    def test_non_string_returns_none(self):
+        self.assertIsNone(self.extractor.get_timestamp(None))
+        self.assertIsNone(self.extractor.get_timestamp(42))
+
+    # ----- Staleness timeout -----
+    def test_staleness_timeout(self):
+        gga = '$GPGGA,140000.00,,,,,,,,,,,,,*xx'
+        self.extractor.get_timestamp(gga)
+
+        # Simulate time passing beyond timeout
+        self.extractor.last_nmea_system_time = time.time() - 10
+
+        vtg = '$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*xx'
+        result = self.extractor.get_timestamp(vtg)
+        self.assertIsNone(result)
+
+    # ----- Date fallback to current UTC date -----
+    def test_gga_uses_current_date_when_no_date_seen(self):
+        gga = '$GPGGA,120000.00,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(gga)
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        self.assertIn(today, result)
+
+    # ----- Microsecond precision -----
+    def test_fractional_seconds(self):
+        record = '$GPGGA,123456.78,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(record)
+        self.assertIn('12:34:56.780000', result)
+
+    # ----- Custom time format -----
+    def test_custom_time_format(self):
+        record = '$GPGGA,093000.00,,,,,,,,,,,,,*xx'
+        fmt = '%H:%M:%S'
+        result = self.extractor.get_timestamp(record, time_format=fmt)
+        self.assertEqual(result, '09:30:00')
+
+    # ----- Cross-sentence date propagation from proprietary -----
+    def test_pgrmf_sets_date_for_gga(self):
+        """PGRMF date should propagate to subsequent GGA."""
+        pgrmf = ('$PGRMF,1234,567890.0,150725,120000,18,'
+                 '4807.038,N,01131.000,E,A,3,12.3,45.6,1.2,3.4*xx')
+        self.extractor.get_timestamp(pgrmf)
+
+        gga = '$GPGGA,120001.00,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(gga)
+        self.assertIn('2025-07-15', result)
+
+    def test_ptnl_ggk_sets_date_for_gga(self):
+        """PTNL,GGK date should propagate to subsequent GGA."""
+        ggk = ('$PTNL,GGK,091500.00,010226,'
+               '4807.038,N,01131.000,E,1,08,1.2,45.6*xx')
+        self.extractor.get_timestamp(ggk)
+
+        gga = '$GPGGA,091501.00,,,,,,,,,,,,,*xx'
+        result = self.extractor.get_timestamp(gga)
+        self.assertIn('2026-02-01', result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `NMEATimestampExtractor` utility class (`logger/utils/nmea_timestamp.py`) that parses timestamps from all common NMEA 0183 sentences: standard (GGA, GLL, RMC, ZDA, GBS, GST, GNS, BWC, TLL, TTM) and proprietary (PASHR, PGRMF, PTNL GGK/PJK, PUBX 00/04, PSIMSNS, PSIMSSB, PSXN 26)
- Extend `TimestampTransform` with `use_nmea_timestamp`, `nmea_timestamp_timeout`, and `nmea_time_drift_threshold` parameters to use NMEA-embedded time instead of the system clock
- Log warnings when NMEA time drifts from system time or when falling back to system time (controllable via `quiet` flag)
- Table-driven design makes adding new sentence types straightforward

## Test plan

- [ ] `python -m pytest test/logger/utils/test_nmea_timestamp.py -v` — 34 unit tests covering all sentence types, date propagation, staleness, fallback behavior
- [ ] `python -m pytest test/logger/transforms/test_timestamp_transform.py -v` — 14 integration tests through TimestampTransform
- [ ] `flake8 logger/utils/nmea_timestamp.py logger/transforms/timestamp_transform.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)