### PR TITLE
Add legacy NMEA met sentences (MTA, MHU, MMB) to NMEA_Meteo

### DIFF
--- a/logger/devices/NMEA_0183.yaml
+++ b/logger/devices/NMEA_0183.yaml
@@ -1068,6 +1068,16 @@ NMEA_Meteo:
       - "${:2l}XDR,{Type1:nc},{Value1:of},{Units1:nc},{Name1:nc},{Type2:nc},{Value2:of},{Units2:nc},{Name2:nc},{Type3:nc},{Value3:of},{Units3:nc},{Name3:nc}*{CheckSum:x}"
       - "${:2l}XDR,{Type1:nc},{Value1:of},{Units1:nc},{Name1:nc},{Type2:nc},{Value2:of},{Units2:nc},{Name2:nc},{Type3:nc},{Value3:of},{Units3:nc},{Name3:nc},{Type4:nc},{Value4:of},{Units4:nc},{Name4:nc}*{CheckSum:x}"
 
+    # Air Temperature (deprecated NMEA, superseded by XDR; still used by Vaisala WI talker)
+    MTA: "${:2l}MTA,{AirTemp:of},{Units:ow}*{CheckSum:x}"
+
+    # Relative Humidity and Dew Point (deprecated NMEA, superseded by XDR; still used by Vaisala WI talker)
+    # AbsHumidity is optional (of) to handle instruments that omit it (e.g. $WIMHU,80,,15.4,C)
+    MHU: "${:2l}MHU,{RelHumidity:of},{AbsHumidity:of},{DewPoint:of},{DewPointUnits:ow}*{CheckSum:x}"
+
+    # Barometric Pressure (deprecated NMEA, superseded by XDR; still used by Vaisala WI talker)
+    MMB: "${:2l}MMB,{BaroInches:of},{BaroInchesUnit:ow},{BaroBars:of},{BaroBarsUnit:ow}*{CheckSum:x}"
+
     ########################################
     # Proprietary: Sea-Bird Scientific
     ########################################
@@ -1153,6 +1163,12 @@ NMEA_Meteo:
       description: "Transducer 4 units"
     Name4:
       description: "Transducer 4 name"
+    DewPointUnits:
+      description: "C=Celsius, F=Fahrenheit"
+    BaroInchesUnit:
+      description: "I=inches of mercury"
+    BaroBarsUnit:
+      description: "B=bars"
     # Sea-Bird fields
     Conductivity:
       units: "S/m"


### PR DESCRIPTION
Closes #521

## Summary

- Adds `MTA` (air temperature), `MHU` (relative humidity + dew point), and `MMB` (barometric pressure) format entries to the `NMEA_Meteo` device type in `logger/devices/NMEA_0183.yaml`
- Adds three new field definitions: `DewPointUnits`, `BaroInchesUnit`, `BaroBarsUnit`

## Background

These are deprecated NMEA 0183 sentences (superseded by `XDR`) but still widely output by mast-mounted weather instruments, notably Vaisala sensors using the `WI` (Weather Instruments) talker prefix (`$WIMTA`, `$WIMHU`, `$WIMMB`). Previously, ships needing these sentences had to define them in local device files with hardcoded talker prefixes (e.g. `local/agulhas2/devices/agulhas2_devices.yaml`).

Using the existing `${:2l}` two-letter talker wildcard pattern, the new entries will automatically match any talker, including `WI`.

## Notes

- `MWV` and `MWD` (wind) were already handled by `NMEA_Wind` via `${:2l}` — no change needed there
- `AbsHumidity` in `MHU` uses `of` (optional float) to handle instruments like Vaisala that omit that field (e.g. `$WIMHU,80,,15.4,C`)
- Tested against sample Pelican Vaisala data in `local/udel/pelican/` — those files use `$WIXDR` and `$WIMWV`, both already parsed correctly without these additions

## Test plan

- [x] YAML validation passed on commit
- [ ] Confirm `$WIMTA`, `$WIMHU`, `$WIMMB` parse correctly with `NMEA_Meteo` device type