### PR TITLE
fix multicast on reader and writer

### DIFF
--- a/logger/readers/udp_reader.py
+++ b/logger/readers/udp_reader.py
@@ -3,6 +3,7 @@
 import logging
 import socket
 import sys
+import ipaddress
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
@@ -55,6 +56,7 @@ class UDPReader(Reader):
         port         Port to listen to for packets.  REQUIRED
 
         mc_group     If specified, IP address of multicast group id to subscribe to.
+                    Must be in range 224.0.0.0 to 239.255.255.255
 
         reuseaddr    Specifies wether we set SO_REUSEADDR on the created socket.  If
                      you don't know you need this, don't enable it.
@@ -96,14 +98,13 @@ class UDPReader(Reader):
         if mc_group:
             # resolve once in constructor
             mc_group = socket.gethostbyname(mc_group)
+
+            if not ipaddress.ip_address(mc_group).is_multicast:
+                logging.error("mc_interface %s IPV4 Multicast addresses use reserved class D address range: 224.0.0.0 through 239.255.255.255", mc_group)
+                raise TypeError('must specify valid mc_interface')
+
             if not interface:
-                # multicast needs to specify interface to use, so let's pick a
-                # sane default
-                #
-                # NOTE: This means hostname cannot be an alias to localhost, or
-                #       you won't be able to send IGMP packets correctly.
-                #
-                self.interface = socket.gethostbyname(socket.gethostname())
+                self.interface = ''
 
         self.mc_group = mc_group
 
@@ -145,32 +146,15 @@ class UDPReader(Reader):
         # If mc_group is specified, subscribe to it as a multicast group
         if self.mc_group:
             # set outgoing multicast interface
-            #
-            # NOTE: Can't use loopback device for this, otherwise IGMP packets
-            #       never leave the system, and you never actually join the
-            #       group.
-            #
-            if self.interface.startswith('127.') and not self.this_is_a_test:
-                logging.warning("Can't use loopback device for joining multicast groups.  Make "
-                                "sure your system's hostname does NOT resolve to something in "
-                                "the 127.0.0.0/8 address block (e.g., localhost, 127.0.0.1), or "
-                                "specify the interface to use by passing its IP address as the "
-                                "`interface` parameter.  (You can ignore this message if you're "
-                                "actually just doing loopback testing.)")
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
                             socket.inet_aton(self.interface))
 
             # join the group via IGMP
-            #
-            # NOTE: Since these are both already encoded as binary by
-            #       inet_aton(), we can just concatenate them.  Alternatively,
-            #       could use struct.pack("4s4s", ...) to create a struct to
-            #       pass into setsockopt()
-            #
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
-                            socket.inet_aton(self.mc_group) + socket.inet_aton(self.interface))
+            mreq = struct.pack("4sl", socket.inet_aton(self.mc_group),
+                               socket.INADDR_ANY)
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
 
-            # bind to mc_group:port
+            # bind to '':port as we have already subscribed to the group above
             sock.bind((self.mc_group, self.port))
 
         else:

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -176,6 +176,14 @@ class UDPWriter(Writer):
         if mc_interface:
             # resolve once in constructor
             mc_interface = socket.gethostbyname(mc_interface)
+
+            if not ipaddress.ip_address(mc_interface).is_multicast:
+                logging.error("mc_interface %s IPV4 Multicast addresses use reserved class D address range: 224.0.0.0 through 239.255.255.255", mc_interface)
+                raise TypeError('must specify valid mc_interface')
+
+            # Set the destination to the mc_interface as we are using sendto()
+            self.destination = mc_interface
+
         self.mc_interface = mc_interface
         self.mc_ttl = mc_ttl
 
@@ -211,20 +219,12 @@ class UDPWriter(Writer):
             # set the time-to-live for messages
             udp_socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL,
                                   struct.pack('b', self.mc_ttl))
-            # set outgoing multicast interface
-            udp_socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
-                                  socket.inet_aton(self.mc_interface))
         else:
             # maybe broadcast, but very non-trivial to detect broadcast IP, so
             # we set the broadcast flag anytime we're not doing multicast
             udp_socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, True)
 
-        try:
-            udp_socket.connect((self.destination, self.port))
-            return udp_socket
-        except OSError as e:
-            logging.error('Unable to connect to %s:%d - %s', self.destination, self.port, e)
-            return None
+        return udp_socket
 
     ############################
     def write(self, record: Union[str, bytes, DASRecord]):
@@ -286,7 +286,7 @@ class UDPWriter(Writer):
         rec_len = len(record)
         while num_tries <= self.num_retry and bytes_sent < rec_len:
             try:
-                bytes_sent = self.socket.send(record)
+                bytes_sent = self.socket.sendto(record, (self.destination, self.port))
 
                 # If here, write succeeded. Reset warnings
                 #

--- a/logger/writers/udp_writer.py
+++ b/logger/writers/udp_writer.py
@@ -5,6 +5,7 @@ import logging
 import socket
 import struct
 import sys
+import ipaddress
 
 from typing import Union
 

--- a/test/logger/writers/test_udp_writer.py
+++ b/test/logger/writers/test_udp_writer.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 import unittest
+import struct
 
 sys.path.append('.')
 from logger.writers.udp_writer import UDPWriter  # noqa E402

--- a/test/logger/writers/test_udp_writer.py
+++ b/test/logger/writers/test_udp_writer.py
@@ -166,29 +166,31 @@ class TestUDPWriter(unittest.TestCase):
     #
     def test_multicast(self):
         # Main method starts here
-        host = "239.192.0.100"
+        mc_interface = "239.192.0.100"
+        dest = ''
         port = 8004
         ttl = 3
         source_ip = socket.gethostbyname(socket.gethostname())
 
-        sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
+        sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM, proto=socket.IPPROTO_UDP)
 
         # join the multicast group
-        logging.info("joing %s to multicast group %s", source_ip, host)
-        # NOTE: Since these are both already encoded as binary by inet_aton(),
-        #       we can just concatenate them.  Alternatively, could use
-        #       struct.pack("4s4s", ...)
-        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
-                        socket.inet_aton(host) + socket.inet_aton(source_ip))
+        logging.info("joing %s to multicast group %s", source_ip, mc_interface)
 
-        # bind to the mc host, port
-        sock.bind((host, port))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+
+        mreq = struct.pack("4sl", socket.inet_aton(mc_interface),
+                           socket.INADDR_ANY)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+        # Just bind to the port, we're already joined to the group.
+        sock.bind((dest, port))
 
         # Start the writer
         threading.Thread(target=self.write,
-                         args=(host, port),
+                         args=(dest, port),
                          kwargs={"data": SAMPLE_DATA, "interval": 0.1,
-                                 "mc_interface": source_ip, "mc_ttl": ttl}).start()
+                                 "mc_interface": mc_interface, "mc_ttl": ttl}).start()
 
         # Set timeout we can catch if things are taking too long
         signal.signal(signal.SIGALRM, self._handler)

--- a/test/logger/writers/test_udp_writer.py
+++ b/test/logger/writers/test_udp_writer.py
@@ -167,7 +167,6 @@ class TestUDPWriter(unittest.TestCase):
     def test_multicast(self):
         # Main method starts here
         mc_interface = "239.192.0.100"
-        dest = ''
         port = 8004
         ttl = 3
         source_ip = socket.gethostbyname(socket.gethostname())
@@ -184,11 +183,11 @@ class TestUDPWriter(unittest.TestCase):
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
 
         # Just bind to the port, we're already joined to the group.
-        sock.bind((dest, port))
+        sock.bind(('', port))
 
         # Start the writer
         threading.Thread(target=self.write,
-                         args=(dest, port),
+                         args=('', port),
                          kwargs={"data": SAMPLE_DATA, "interval": 0.1,
                                  "mc_interface": mc_interface, "mc_ttl": ttl}).start()
 


### PR DESCRIPTION
Both: Added checking for the multicast IP range

UDP Reader: Added membership for the mc_group, then bound to '' as we have already joined. Also don't need to specify any other random destination.

UDP Writer: Generally speaking, send() is used for TCP SOCK_STREAM connected sockets, and sendto() is used for UDP SOCK_DGRAM unconnected datagram sockets. (https://www.gta.ufrj.br/ensino/eel878/sockets/sendman.html) So changed both cases to use sendto, now we don't need to add membership or connect to the socket