### PR TITLE
Update default UDP reader interface setup (INADDR_ANY), clarify bind and sockopts logic

### DIFF
--- a/logger/readers/udp_reader.py
+++ b/logger/readers/udp_reader.py
@@ -2,11 +2,7 @@
 
 import logging
 import socket
-<<<<<<< HEAD
-=======
-import sys
 import struct
->>>>>>> cd2d034 (Move to using socket.IPADDR_ANY as the fallback interface for multicast read, and remove redundant IP_MULTICAST_IF sockopt)
 
 from logger.readers.reader import Reader  # noqa: E402
 

--- a/logger/readers/udp_reader.py
+++ b/logger/readers/udp_reader.py
@@ -2,6 +2,11 @@
 
 import logging
 import socket
+<<<<<<< HEAD
+=======
+import sys
+import struct
+>>>>>>> cd2d034 (Move to using socket.IPADDR_ANY as the fallback interface for multicast read, and remove redundant IP_MULTICAST_IF sockopt)
 
 from logger.readers.reader import Reader  # noqa: E402
 
@@ -93,14 +98,6 @@ class UDPReader(Reader):
         if mc_group:
             # resolve once in constructor
             mc_group = socket.gethostbyname(mc_group)
-            if not interface:
-                # multicast needs to specify interface to use, so let's pick a
-                # sane default
-                #
-                # NOTE: This means hostname cannot be an alias to localhost, or
-                #       you won't be able to send IGMP packets correctly.
-                #
-                self.interface = socket.gethostbyname(socket.gethostname())
 
         self.mc_group = mc_group
 
@@ -154,8 +151,6 @@ class UDPReader(Reader):
                                 "specify the interface to use by passing its IP address as the "
                                 "`interface` parameter.  (You can ignore this message if you're "
                                 "actually just doing loopback testing.)")
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
-                            socket.inet_aton(self.interface))
 
             # join the group via IGMP
             #
@@ -164,11 +159,21 @@ class UDPReader(Reader):
             #       could use struct.pack("4s4s", ...) to create a struct to
             #       pass into setsockopt()
             #
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
-                            socket.inet_aton(self.mc_group) + socket.inet_aton(self.interface))
+            if self.interface:
+                sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                                socket.inet_aton(self.mc_group) + socket.inet_aton(self.interface))
+            else:
+                mreq = struct.pack("4sl", socket.inet_aton(self.mc_group), socket.INADDR_ANY)
+                sock.setsockopt(
+                    socket.IPPROTO_IP, 
+                    socket.IP_ADD_MEMBERSHIP, 
+                    mreq
+                )
 
-            # bind to mc_group:port
-            sock.bind((self.mc_group, self.port))
+
+            # bind
+            # don't need to specify mc_group address because we have already joined above
+            sock.bind(('', self.port))
 
         else:
             # broadcast or unicast, bind to specificed interface

--- a/logger/readers/udp_reader.py
+++ b/logger/readers/udp_reader.py
@@ -44,9 +44,7 @@ class UDPReader(Reader):
         """
         ```
         interface    IP (or resolvable name) of interface to listen on.  None or ''
-                     will listen on INADDR_ANY (all interfaces).  If joining a
-                     multicast group and None or '' specified, this will default
-                     to whatever the system's hostname resolves to.  This IP should
+                     will listen on INADDR_ANY (all interfaces). This IP should
                      not be on the loopback network (OK for testing, but won't work
                      in the real world).
 
@@ -70,13 +68,6 @@ class UDPReader(Reader):
         """
         super().__init__(**kwargs)
 
-        if interface:
-            # resolve once in constructor
-            interface = socket.gethostbyname(interface)
-        else:
-            interface = ''
-        self.interface = interface
-
         # make sure user passed in `port`
         #
         # NOTE: We want the order of the arguments to consistently be (ip,
@@ -90,12 +81,17 @@ class UDPReader(Reader):
         # make sure port gets stored as an int, even if passed in as a string
         self.port = int(port)
 
-        # prep multicast parameters
+        # resolve mc_group once in constructor
         if mc_group:
-            # resolve once in constructor
-            mc_group = socket.gethostbyname(mc_group)
-
+            mc_group = socket.inet_aton(socket.gethostbyname(mc_group))
         self.mc_group = mc_group
+
+        # resolve interface once in constructor
+        if interface:
+            interface = socket.inet_aton(socket.gethostbyname(interface))
+        else:
+            interface = socket.INADDR_ANY if self.mc_group else socket.inet_aton('0.0.0.0')
+        self.interface = interface
 
         self.reuseaddr = reuseaddr
         self.reuseport = reuseport
@@ -140,7 +136,7 @@ class UDPReader(Reader):
             #       never leave the system, and you never actually join the
             #       group.
             #
-            if self.interface.startswith('127.') and not self.this_is_a_test:
+            if socket.inet_ntoa(self.interface).startswith('127.') and not self.this_is_a_test:
                 logging.warning("Can't use loopback device for joining multicast groups.  Make "
                                 "sure your system's hostname does NOT resolve to something in "
                                 "the 127.0.0.0/8 address block (e.g., localhost, 127.0.0.1), or "
@@ -149,31 +145,15 @@ class UDPReader(Reader):
                                 "actually just doing loopback testing.)")
 
             # join the group via IGMP
-            #
-            # NOTE: Since these are both already encoded as binary by
-            #       inet_aton(), we can just concatenate them.  Alternatively,
-            #       could use struct.pack("4s4s", ...) to create a struct to
-            #       pass into setsockopt()
-            #
-            if self.interface:
-                sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
-                                socket.inet_aton(self.mc_group) + socket.inet_aton(self.interface))
-            else:
-                mreq = struct.pack("4sl", socket.inet_aton(self.mc_group), socket.INADDR_ANY)
-                sock.setsockopt(
-                    socket.IPPROTO_IP, 
-                    socket.IP_ADD_MEMBERSHIP, 
-                    mreq
-                )
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                            self.mc_group + self.interface)
 
-
-            # bind
-            # don't need to specify mc_group address because we have already joined above
-            sock.bind(('', self.port))
+            # multicast, bind to mc_group
+            sock.bind((socket.inet_ntoa(self.mc_group), self.port))
 
         else:
             # broadcast or unicast, bind to specificed interface
-            sock.bind((self.interface, self.port))
+            sock.bind((socket.inet_ntoa(self.interface), self.port))
 
         return sock
 

--- a/logger/readers/udp_reader.py
+++ b/logger/readers/udp_reader.py
@@ -2,7 +2,6 @@
 
 import logging
 import socket
-import struct
 
 from logger.readers.reader import Reader  # noqa: E402
 
@@ -68,6 +67,13 @@ class UDPReader(Reader):
         """
         super().__init__(**kwargs)
 
+        # resolve interface once in constructor
+        if interface:
+            interface = socket.inet_aton(socket.gethostbyname(interface))
+        else:
+            interface = socket.inet_aton('0.0.0.0')
+        self.interface = interface
+
         # make sure user passed in `port`
         #
         # NOTE: We want the order of the arguments to consistently be (ip,
@@ -85,13 +91,6 @@ class UDPReader(Reader):
         if mc_group:
             mc_group = socket.inet_aton(socket.gethostbyname(mc_group))
         self.mc_group = mc_group
-
-        # resolve interface once in constructor
-        if interface:
-            interface = socket.inet_aton(socket.gethostbyname(interface))
-        else:
-            interface = socket.INADDR_ANY if self.mc_group else socket.inet_aton('0.0.0.0')
-        self.interface = interface
 
         self.reuseaddr = reuseaddr
         self.reuseport = reuseport
@@ -145,6 +144,12 @@ class UDPReader(Reader):
                                 "actually just doing loopback testing.)")
 
             # join the group via IGMP
+            #
+            # NOTE: Since these are both already encoded as binary by
+            #       inet_aton(), we can just concatenate them.  Alternatively,
+            #       could use struct.pack("4s4s", ...) to create a struct to
+            #       pass into setsockopt()
+            #
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
                             self.mc_group + self.interface)
 


### PR DESCRIPTION
Hi folks,

Opening this PR with some suggested changes to the UDP reader, see details below. Feedback welcomed, cheers!

- This PR changes how the UDP reader selects a default interface for reading multicast traffic where one is not specified to the constructor.
  - Currently `self.interface = socket.gethostbyname(socket.gethostname())` is used to derive a default value for the interface. This will resolve to `127.0.1.1` on many Linux machines which is not a useable interface for reading UDP multicast traffic. 
  - The proposed alternative is to use socket.INADDR_ANY, which will let the OS pick a sensible default. This is the approach we currently use on RV Investigator (but would like to realign our reader implementation with what's upstream).

Additionally, this PR makes some minor changes in the interest of clarity:
  - Changes the socket bind for multicast from `sock.bind((self.mc_group, self.port))` to `sock.bind(('', self.port))`. To my understanding there is no need to specify the group in the bind once the IGMP group has been joined with the preceding logic. 
  - Removes the logic setting the `socket.IP_MULTICAST_IF` sockopt for multicast. This option only controls which interface is used for multicast send, and this class does not need to send.