### PR TITLE
[Issue #564] Add AlmaLinux support to install scripts

### DIFF
--- a/utils/install_influxdb.sh
+++ b/utils/install_influxdb.sh
@@ -140,8 +140,8 @@ function get_os_type {
     elif [[ `uname -s` == 'Linux' ]];then
         if [[ ! -z `grep "NAME=\"Ubuntu\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"Debian" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"Raspbian" /etc/os-release` ]];then
             OS_TYPE=Ubuntu
-        # CentOS/RHEL
-        elif [[ ! -z `grep "NAME=\"CentOS Stream\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"CentOS Linux\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"Red Hat Enterprise Linux\"" /etc/os-release` ]]  || [[ ! -z `grep "NAME=\"Rocky Linux\"" /etc/os-release` ]];then
+        # CentOS/RHEL/AlmaLinux
+        elif [[ ! -z `grep "NAME=\"CentOS Stream\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"CentOS Linux\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"Red Hat Enterprise Linux\"" /etc/os-release` ]]  || [[ ! -z `grep "NAME=\"Rocky Linux\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"AlmaLinux\"" /etc/os-release` ]];then
             OS_TYPE=CentOS
             if [[ ! -z `grep "VERSION_ID=\"7" /etc/os-release` ]];then
                 OS_VERSION=7
@@ -149,6 +149,8 @@ function get_os_type {
                 OS_VERSION=8
             elif [[ ! -z `grep "VERSION_ID=\"9" /etc/os-release` ]];then
                 OS_VERSION=9
+            elif [[ ! -z `grep "VERSION_ID=\"10" /etc/os-release` ]];then
+                OS_VERSION=10
             # Rocky Linux uses different format in /etc/os-release
             elif [[ ! -z `grep "VERSION=\"7" /etc/os-release` ]];then
                 OS_VERSION=7
@@ -156,8 +158,10 @@ function get_os_type {
                 OS_VERSION=8
             elif [[ ! -z `grep "VERSION=\"9" /etc/os-release` ]];then
                 OS_VERSION=9
+            elif [[ ! -z `grep "VERSION=\"10" /etc/os-release` ]];then
+                OS_VERSION=10
             else
-                echo "Sorry - unknown CentOS/RHEL Version! - exiting."
+                echo "Sorry - unknown CentOS/RHEL/AlmaLinux Version! - exiting."
                 exit_gracefully
             fi
         else
@@ -373,7 +377,7 @@ function install_packages {
                 sudo ln -s -f /usr/local/bin/pip3.8 /usr/local/bin/pip3
                 popd
             fi
-        elif [ $OS_VERSION == '8' ] || [ $OS_VERSION == '9' ]; then
+        elif [ $OS_VERSION == '8' ] || [ $OS_VERSION == '9' ] || [ $OS_VERSION == '10' ]; then
             sudo yum install -y python3 python3-devel
         else
             echo "Install error: unknown OS_VERSION should have been caught earlier?!?"

--- a/utils/install_openrvdas.sh
+++ b/utils/install_openrvdas.sh
@@ -177,8 +177,8 @@ function get_os_type {
                 exit_gracefully
             fi
 
-        # CentOS/RHEL
-        elif [[ ! -z `grep "NAME=\"CentOS Stream\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"CentOS Linux\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"Red Hat Enterprise Linux\"" /etc/os-release` ]]  || [[ ! -z `grep "NAME=\"Rocky Linux\"" /etc/os-release` ]];then
+        # CentOS/RHEL/AlmaLinux
+        elif [[ ! -z `grep "NAME=\"CentOS Stream\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"CentOS Linux\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"Red Hat Enterprise Linux\"" /etc/os-release` ]]  || [[ ! -z `grep "NAME=\"Rocky Linux\"" /etc/os-release` ]] || [[ ! -z `grep "NAME=\"AlmaLinux\"" /etc/os-release` ]];then
             OS_TYPE=CentOS
             if [[ ! -z `grep "VERSION_ID=\"7" /etc/os-release` ]];then
                 OS_VERSION=7
@@ -186,6 +186,8 @@ function get_os_type {
                 OS_VERSION=8
             elif [[ ! -z `grep "VERSION_ID=\"9" /etc/os-release` ]];then
                 OS_VERSION=9
+            elif [[ ! -z `grep "VERSION_ID=\"10" /etc/os-release` ]];then
+                OS_VERSION=10
             # Rocky Linux uses different format in /etc/os-release
             elif [[ ! -z `grep "VERSION=\"7" /etc/os-release` ]];then
                 OS_VERSION=7
@@ -193,8 +195,10 @@ function get_os_type {
                 OS_VERSION=8
             elif [[ ! -z `grep "VERSION=\"9" /etc/os-release` ]];then
                 OS_VERSION=9
+            elif [[ ! -z `grep "VERSION=\"10" /etc/os-release` ]];then
+                OS_VERSION=10
             else
-                echo "Sorry - unknown CentOS/RHEL Version! - exiting."
+                echo "Sorry - unknown CentOS/RHEL/AlmaLinux Version! - exiting."
                 exit_gracefully
             fi
         else
@@ -594,7 +598,7 @@ function install_prereqs {
                 sudo ln -s -f /usr/local/bin/pip3.8 /usr/local/bin/pip3
                 popd
             fi
-        elif [ $OS_VERSION == '8' ] || [ $OS_VERSION == '9' ]; then
+        elif [ $OS_VERSION == '8' ] || [ $OS_VERSION == '9' ] || [ $OS_VERSION == '10' ]; then
             sudo yum install -y python3 python3-devel
         else
             echo "Install error: unknown OS_VERSION should have been caught earlier?!?"


### PR DESCRIPTION
## Summary

- Adds `AlmaLinux` to the OS name detection in `get_os_type()` alongside CentOS, RHEL, and Rocky Linux in both `utils/install_openrvdas.sh` and `utils/install_influxdb.sh`
- Extends version detection to cover AlmaLinux/RHEL-family versions 8, 9, and 10 (both `VERSION_ID` and `VERSION` formats)
- Extends the Python install logic to include version 10 alongside 8 and 9 (`yum install python3 python3-devel`)

Closes #564

## Test plan

- [ ] Verify `get_os_type` correctly sets `OS_TYPE=CentOS` and `OS_VERSION=10` on an AlmaLinux 10 host
- [ ] Run `install_openrvdas.sh` end-to-end on AlmaLinux 8, 9, and 10
- [ ] Run `install_influxdb.sh` end-to-end on AlmaLinux 8, 9, and 10
- [ ] Confirm existing CentOS/RHEL/Rocky Linux installs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)