### PR TITLE
[Issue #566] Support mirror_to as top-level keyword; refactor serial/UDP templates

### DIFF
--- a/contrib/config_templates/serial_reader_config_template.yaml
+++ b/contrib/config_templates/serial_reader_config_template.yaml
@@ -1,7 +1,7 @@
 ###################
 config_templates:
   #################
-  serial_net_config_template: &serial_net_config_base
+  serial_net_config_template:
     readers:
     - class: SerialReader
       kwargs:
@@ -9,33 +9,32 @@ config_templates:
         port: <<serial_port>>
     transforms:
     - class: TimestampTransform
-    writers:
-    - class: ComposedWriter
+    - class: PrefixTransform
       kwargs:
-        transforms:
-        - class: PrefixTransform
-          kwargs:
-            prefix: <<logger>>
-        writers:
-        - class: UDPWriter
-          kwargs:
-            port: <<raw_udp_port>>
-            destination: <<udp_destination>>
+        prefix: <<logger>>
+    writers:
+    - class: UDPWriter
+      kwargs:
+        port: <<raw_udp_port>>
+        destination: <<udp_destination>>
 
   serial_net_file_config_template:
-    <<: *serial_net_config_base
+    readers:
+    - class: SerialReader
+      kwargs:
+        baudrate: <<baud_rate|9600>>
+        port: <<serial_port>>
+    transforms:
+    - class: TimestampTransform
+      mirror_to:
+        class: LogfileWriter
+        kwargs:
+          filebase: <<file_root>>/<<logger>>/raw/<<cruise>>_<<logger>>
+    - class: PrefixTransform
+      kwargs:
+        prefix: <<logger>>
     writers:
-    - class: LogfileWriter
+    - class: UDPWriter
       kwargs:
-        filebase: <<file_root>>/<<logger>>/raw/<<cruise>>_<<logger>>
-    - class: ComposedWriter
-      kwargs:
-        transforms:
-        - class: PrefixTransform
-          kwargs:
-            prefix: <<logger>>
-        writers:
-        - class: UDPWriter
-          kwargs:
-            port: <<raw_udp_port>>
-            destination: <<udp_destination>>
+        port: <<raw_udp_port>>
+        destination: <<udp_destination>>

--- a/contrib/logger_templates/serial_logger_template.yaml
+++ b/contrib/logger_templates/serial_logger_template.yaml
@@ -28,18 +28,15 @@ logger_templates:
             port: <<serial_port>>
         transforms:
         - class: TimestampTransform
+          mirror_to:
+            class: LogfileWriter
+            kwargs:
+              filebase: <<file_root>>/<<logger>>/raw/<<cruise>>_<<logger>>
+        - class: PrefixTransform
+          kwargs:
+            prefix: <<logger>>
         writers:
-        - class: LogfileWriter
+        - class: UDPWriter
           kwargs:
-            filebase: <<file_root>>/<<logger>>/raw/<<cruise>>_<<logger>>
-        - class: ComposedWriter
-          kwargs:
-            transforms:
-            - class: PrefixTransform
-              kwargs:
-                prefix: <<logger>>
-            writers:
-            - class: UDPWriter
-              kwargs:
-                port: <<raw_udp_port>>
-                destination: <<udp_destination>>
+            port: <<raw_udp_port>>
+            destination: <<udp_destination>>

--- a/contrib/logger_templates/udp_logger_template.yaml
+++ b/contrib/logger_templates/udp_logger_template.yaml
@@ -26,18 +26,15 @@ logger_templates:
             port: <<reader_udp_port>>
         transforms:
         - class: TimestampTransform
+          mirror_to:
+            class: LogfileWriter
+            kwargs:
+              filebase: <<file_root>>/<<logger>>/raw/<<cruise>>_<<logger>>
+        - class: PrefixTransform
+          kwargs:
+            prefix: <<logger>>
         writers:
-        - class: LogfileWriter
+        - class: UDPWriter
           kwargs:
-            filebase: <<file_root>>/<<logger>>/raw/<<cruise>>_<<logger>>
-        - class: ComposedWriter
-          kwargs:
-            transforms:
-            - class: PrefixTransform
-              kwargs:
-                prefix: <<logger>>
-            writers:
-            - class: UDPWriter
-              kwargs:
-                port: <<raw_udp_port>>
-                destination: <<udp_destination>>
+            port: <<raw_udp_port>>
+            destination: <<udp_destination>>

--- a/logger/listener/listen.py
+++ b/logger/listener/listen.py
@@ -164,6 +164,12 @@ class ListenerFromLoggerConfig(Listener):
         if not kwargs:
             logging.debug('No kwargs found for component {}'.format(class_name))
 
+        # Support mirror_to as a top-level sibling of 'class'/'kwargs'.
+        # mirror_to inside kwargs also works and is grandfathered.
+        mirror_to_spec = class_json.get('mirror_to')
+        if mirror_to_spec and 'mirror_to' not in kwargs:
+            kwargs['mirror_to'] = self._class_kwargs_from_config(mirror_to_spec)
+
         # Instantiate!
         logging.debug('Instantiating {}({})'.format(class_name, kwargs))
         try:


### PR DESCRIPTION
## Summary

Cherry-pick of #568 (merged to `dev`) onto `master`, touching only the 4 files changed in that PR.

Current implementation had a mismatch with documentation. [Documentation](https://www.oceandatatools.org/openrvdas-docs/logger_configuration_files/#tapping-a-reader-or-transform-with-mirror_to) indicated that `mirror_to` was a top-level keyword (like `class`), while implementation looked for it inside `kwargs`. Current PR accepts it as top-level, but retains backward compatibilty if it appears inside `kwargs`

- **Fix `mirror_to` parsing in `listen.py`** — `_class_kwargs_from_config` now detects `mirror_to` at the component level (alongside `class` and `kwargs`) and instantiates it as a `Writer` before passing it to the constructor. This matches the documented style. `mirror_to` inside `kwargs` continues to work and is grandfathered.
- **Refactor serial/UDP logger templates** — Replaces the `LogfileWriter` + `ComposedWriter(PrefixTransform, UDPWriter)` pattern in `net+file` configs with `TimestampTransform(mirror_to=LogfileWriter)` + `PrefixTransform` + `UDPWriter` directly in the pipeline. Eliminates unnecessary `ComposedWriter` nesting in `net`-only configs as well.
- **Remove YAML anchor/merge in `serial_reader_config_template.yaml`** — the two config templates now differ at the `transforms` level so the anchor no longer applies.

## Files changed

- `contrib/config_templates/serial_reader_config_template.yaml`
- `contrib/logger_templates/serial_logger_template.yaml`
- `contrib/logger_templates/udp_logger_template.yaml`
- `logger/listener/listen.py`

## Test plan

- [ ] Expand a cruise definition that uses `serial_logger_template` and confirm the generated `net` and `net+file` configs are structurally correct
- [ ] Confirm `net+file` loggers write timestamped raw data to file and prefixed data to UDP as expected
- [ ] Confirm `mirror_to` specified inside `kwargs` still works (backwards compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)