### PR TITLE
[Issue #584] Fix git clone permission error when installer is run by non-rvdas user

### DIFF
--- a/utils/install_openrvdas.sh
+++ b/utils/install_openrvdas.sh
@@ -641,7 +641,10 @@ function install_openrvdas {
     if [ ! -e openrvdas ]; then
       echo "Making openrvdas directory."
       sudo mkdir openrvdas
-      sudo chown ${RVDAS_USER} openrvdas
+      # Give the directory to the invoking user for now so the git/cp/sed
+      # operations below can run unprivileged; the end of this script hands
+      # the whole tree to ${RVDAS_USER}.
+      sudo chown $(id -un) openrvdas
     fi
 
     # If FIPS is active, we need this to prevent it from complaining
@@ -649,6 +652,10 @@ function install_openrvdas {
 
     if [ -e openrvdas/.git ] ; then   # If we've already got an installation
       cd openrvdas
+      # A previous run will have left the tree owned by ${RVDAS_USER}; take
+      # ownership so the git/cp/sed operations below can run as the invoking
+      # user. The end of this script hands everything back to ${RVDAS_USER}.
+      sudo chown -R $(id -un) .
       # Ensure origin points to the requested repo (may differ on re-installs)
       echo "Fetching branch '$OPENRVDAS_BRANCH' from $OPENRVDAS_REPO"
       git remote set-url origin "$OPENRVDAS_REPO"
@@ -665,7 +672,10 @@ function install_openrvdas {
     else                              # If we don't already have an installation
       sudo rm -rf openrvdas           # in case there's a non-git dir there
       sudo mkdir openrvdas
-      sudo chown ${RVDAS_USER} openrvdas
+      # Owned by the invoking user so 'git clone' (run unprivileged, below)
+      # can write into it; the end of this script hands the whole tree to
+      # ${RVDAS_USER}.
+      sudo chown $(id -un) openrvdas
       if ! git clone -b "$OPENRVDAS_BRANCH" "$OPENRVDAS_REPO" ; then
         echo "ERROR: Failed to clone branch '$OPENRVDAS_BRANCH' from $OPENRVDAS_REPO"
         exit_gracefully


### PR DESCRIPTION
## Summary

Fixes #584.

`install_openrvdas.sh` pre-creates `${INSTALL_ROOT}/openrvdas` and chowns it to `RVDAS_USER` *before* running `git clone` as the invoking user. When the invoking user differs from `RVDAS_USER` — exactly the documented curl-download install flow on a fresh box, choosing `rvdas` as the OpenRVDAS user — the clone cannot write into the rvdas-owned, mode-755 directory and dies with `/opt/openrvdas/.git: Permission denied`. It goes unnoticed when the installer is run from an existing clone because there `RVDAS_USER` defaults to the invoking user, making the chown a no-op permission-wise.

## What changed (utils/install_openrvdas.sh, `install_openrvdas()`)

- **Fresh-clone path (the reported bug):** chown the freshly created `openrvdas/` directory to the invoking user (`$(id -un)`) instead of `RVDAS_USER`, in both places it is created. The script already does `sudo chown -R ${RVDAS_USER} ${INSTALL_ROOT}/openrvdas` at the end, so final ownership is unchanged.
- **Existing-install path (same root cause, one line):** take ownership of the tree (`sudo chown -R $(id -un) .`) before the `git fetch`/`git pull`/`cp`/`sed` operations, since a previous run leaves the tree rvdas-owned and the script is documented as safe to re-run for upgrades. The final chown hands it back.

`$(id -un)` is used rather than `$USER` so the change is correct even if the whole script is run under `sudo`.

Verified nothing between the clone and the end-of-script chown runs as `RVDAS_USER` or starts services against the tree, so intermediate invoking-user ownership matches what already happens on the common (invoker == rvdas) path.

## Tests

- `bash -n` passes.
- Logic-level verification as above; I don't have a throwaway Ubuntu box handy to run the full installer — @mcastells, this should be easy to confirm on your VirtualBox reproduction if you're willing.

A follow-up PR will cherry-pick this onto `master`, since the published install instructions point users there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)