### PR TITLE
Fix typo in logging message in udp_reader.py

### DIFF
--- a/logger/readers/udp_reader.py
+++ b/logger/readers/udp_reader.py
@@ -187,7 +187,7 @@ class UDPReader(Reader):
             if record.endswith(FRAGMENT_MARKER):
                 # UDPWriter fragmented this record because it was too large to
                 # send as a single datagram
-                logging.info('UDPrader.read: detected fragmented packet')
+                logging.info('UDPReader.read: detected fragmented packet')
                 record_buffer += record.rsplit(FRAGMENT_MARKER, maxsplit=1)[0]
                 logging.debug('record_buffer: %s', record_buffer)
             else:


### PR DESCRIPTION
Noticed tiny typo while reading the code. Not urgent or anything as it's just a log message, but hopefully also a trivial thing to fix with no side effects (assuming no one is depending on fixed string log messages :)).