### PR TITLE
Fix typo in logging message in udp_reader.py (cherry-pick of #588)

### DIFF
--- a/logger/readers/udp_reader.py
+++ b/logger/readers/udp_reader.py
@@ -187,7 +187,7 @@ class UDPReader(Reader):
             if record.endswith(FRAGMENT_MARKER):
                 # UDPWriter fragmented this record because it was too large to
                 # send as a single datagram
-                logging.info('UDPrader.read: detected fragmented packet')
+                logging.info('UDPReader.read: detected fragmented packet')
                 record_buffer += record.rsplit(FRAGMENT_MARKER, maxsplit=1)[0]
                 logging.debug('record_buffer: %s', record_buffer)
             else:


### PR DESCRIPTION
Cherry-picks f6974b44 (#588, merged to `master`) onto `dev`.

`dev` still carried the same typo, so without this the fix would be lost the next time `dev` is merged to `master`.

## What changed

One log message in `logger/readers/udp_reader.py`:

`'UDPrader.read: detected fragmented packet'` → `'UDPReader.read: detected fragmented packet'`

Log text only — no behavior change.

## Tests

No tests added or modified; this is a string fix.

- `pytest test/logger/readers/test_udp_reader.py` — 7 passed
- `pytest test/logger/readers/ test/logger/writers/` — 129 passed, 40 skipped
- `flake8 logger/readers/udp_reader.py` — clean

## Note

The typo also appears in the generated API docs under `docs/html/`. Those are regenerated by the docs workflow, so they are intentionally left untouched here.

Original commit authored by Peter (@peter-csiro); authorship preserved by the cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)