### PR TITLE
Make geopandas/shapely optional so ARM installs don't fail on GDAL

### DIFF
--- a/logger/transforms/geofence_transform.py
+++ b/logger/transforms/geofence_transform.py
@@ -64,6 +64,10 @@ try:
 except ImportError:
     import_errors = True
 
+# Exported so that callers and tests can check whether geofencing is
+# available without having to import geopandas/shapely themselves.
+GEOFENCE_ENABLED = not import_errors
+
 import_pandas_errors = False
 try:
     import pandas as pd
@@ -116,8 +120,8 @@ class GeofenceTransform(Transform):
         # Only throw this error if user tries to actually use this code
         if import_errors:
             raise ImportError('GeofenceTransform requires installation of geopandas and '
-                              'shapely packages. Please run "pip install geopandas shapely" '
-                              'and retry.')
+                              'shapely packages. Please run "pip install \'.[geofence]\'" '
+                              '(or "pip install geopandas shapely") and retry.')
 
         super().__init__(**kwargs)  # processes 'quiet' and type hints
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,19 +17,21 @@ dependencies = [
   "django",
   "djangorestframework",
   "drf-spectacular[sidecar]",
-  "geopandas",
   "influxdb_client",
   "parse",
   "psutil",
   "pyModbusTCP",
   "pyserial",
   "setproctitle",
-  "shapely",
   "uwsgi",
   "websockets"
 ]
 
 [project.optional-dependencies]
+geofence = [
+  "geopandas",
+  "shapely"
+]
 google = [
   "google-api-python-client",
   "google-auth-httplib2",

--- a/test/logger/transforms/test_geofence_transform.py
+++ b/test/logger/transforms/test_geofence_transform.py
@@ -9,7 +9,7 @@ import time
 import unittest
 
 from logger.utils.das_record import DASRecord  # noqa: E402
-from logger.transforms.geofence_transform import GeofenceTransform  # noqa: E402
+from logger.transforms.geofence_transform import GeofenceTransform, GEOFENCE_ENABLED  # noqa: E402
 
 # EEZ of Togo
 BOUNDARY_GML = """<?xml version="1.0" encoding="UTF-8"?>
@@ -103,6 +103,9 @@ BOUNDARY_RESULT = [
 SECONDS_RESULT = [
     'leaving', None, None, None, 'entering', None, None, None, None, None, 'leaving', None, None
 ]
+@unittest.skipUnless(GEOFENCE_ENABLED,
+                     'geopandas/shapely not installed; '
+                     "run: pip install '.[geofence]'")
 class TestGeofenceTransform(unittest.TestCase):
     ############################
     @classmethod

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -17,9 +17,16 @@ setproctitle
 influxdb_client
 pyModbusTCP
 
-# For Geofencing
-geopandas
-shapely
+# For Geofencing (optional - used only by GeofenceTransform).
+#
+# Not installed by default: geopandas pulls in pyogrio, which has no prebuilt
+# wheel for ARMv6/ARMv7 and requires libgdal-dev to compile from source. That
+# makes a default install fail on Raspberry Pi and similar hardware.
+#
+# To enable geofencing:
+#   pip install '.[geofence]'
+#geopandas
+#shapely
 
 django
 djangorestframework


### PR DESCRIPTION
## Problem

`geopandas` and `shapely` are hard dependencies in **both** `pyproject.toml` and `utils/requirements.txt`, even though the only code that uses them — `GeofenceTransform` — already guards its imports and defers the error until the transform is actually instantiated.

This breaks installs on ARM. `geopandas` pulls in `pyogrio`, which has no prebuilt wheel for ARMv6/ARMv7 and requires `libgdal-dev` to build from source. On a Raspberry Pi Zero the install dies with:

```
File "<string>", line 39, in read_response
FileNotFoundError: [Errno 2] No such file or directory: 'gdal-config'
error: metadata-generation-failed
```

## Why both files had to change

`utils/install_openrvdas.sh` runs both:

```bash
venv/bin/python venv/bin/pip3 install -r utils/requirements.txt   # line 778
if [ -f pyproject.toml ]; then
    venv/bin/python venv/bin/pip3 install -e .                     # line 783
fi
```

Patching only one leaves the other to pull GDAL anyway — worth knowing for anyone applying a local workaround.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | Move `geopandas`/`shapely` into a `geofence` extra, matching the existing `google`/`mysql`/`redis`/`mqtt` groups |
| `utils/requirements.txt` | Comment them out, with a note on why and how to re-enable |
| `logger/transforms/geofence_transform.py` | Export `GEOFENCE_ENABLED`; point the `ImportError` at the new extra |
| `test/logger/transforms/test_geofence_transform.py` | `skipUnless(GEOFENCE_ENABLED, ...)` so the suite skips rather than fails |

Geofencing becomes opt-in:

```bash
pip install '.[geofence]'
```

## The test guard is required, not optional polish

`test_geofence_transform.py` instantiates `GeofenceTransform` with no guard, so removing the dependency would turn 9 passing tests into 9 **failures**. The `skipUnless` guard follows the pattern already used by `test_google_sheets_writer.py` (`GOOGLE_SHEETS_ENABLED`) and the database connector tests.

## Behavior change to be aware of

Geofencing is no longer installed by default. Anyone relying on `GeofenceTransform` who re-runs the installer will need `pip install '.[geofence]'`. The failure is loud and self-explanatory rather than silent — the transform raises an `ImportError` naming the exact command — but it is a real change and reviewers should weigh it.

An alternative considered was a PEP 508 environment marker (`geopandas; platform_machine not in "armv6l armv7l"`), which would regress nobody. It was rejected as a guess about which platforms lack wheels, and because it leaves `pyproject.toml` and `requirements.txt` expressing different rules.

## Tests

- `pytest test/` — **404 passed, 51 skipped** (full suite, geopandas present)
- `pytest test/logger/transforms/test_geofence_transform.py` — 9 passed with geopandas installed
- Same file with `geopandas`/`shapely` blocked at import — **9 skipped, 0 failed** (verified with an injected import blocker)
- Verified `import logger.transforms` still succeeds without geopandas, and that instantiating `GeofenceTransform` raises the new message
- `flake8` clean on both changed Python files

No new dependencies added; this only moves existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)