### PR TITLE
Move Django/uwsgi into a "web" extra for logger-only installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,20 +14,25 @@ authors = [
 ]
 dependencies = [
   "PyYAML",
-  "django",
-  "djangorestframework",
-  "drf-spectacular[sidecar]",
   "influxdb_client",
   "parse",
   "psutil",
   "pyModbusTCP",
   "pyserial",
   "setproctitle",
-  "uwsgi",
   "websockets"
 ]
 
 [project.optional-dependencies]
+# Django web console (UI_TYPE=django) and the nginx/uwsgi stack that serves
+# it. Not needed to run loggers, or for the React UI, which has its own
+# dependencies under web_backend/.
+web = [
+  "django",
+  "djangorestframework",
+  "drf-spectacular[sidecar]",
+  "uwsgi"
+]
 geofence = [
   "geopandas",
   "shapely"

--- a/test/django_gui/test_api_views.py
+++ b/test/django_gui/test_api_views.py
@@ -6,18 +6,24 @@ Run with: ./manage.py test test.django_gui.test_api_views
 Or: python -m pytest test/django_gui/test_api_views.py
 """
 
-import django
 import os
 import unittest
 from unittest import mock
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_gui.settings')
-django.setup()
+# Django is an optional extra ("pip install '.[web]'"); skip rather than
+# error out at collection time if it isn't installed.
+try:
+    import django
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_gui.settings')
+    django.setup()
 
-from django.test import TestCase, override_settings  # noqa: E402
-from django.contrib.auth.models import User  # noqa: E402
-from rest_framework.test import APIClient  # noqa: E402
-from rest_framework.authtoken.models import Token  # noqa: E402
+    from django.test import TestCase, override_settings  # noqa: E402
+    from django.contrib.auth.models import User  # noqa: E402
+    from rest_framework.test import APIClient  # noqa: E402
+    from rest_framework.authtoken.models import Token  # noqa: E402
+except ImportError:
+    raise unittest.SkipTest(
+        "Django not installed; run: pip install '.[web]'")
 
 
 # Sample cruise configuration for testing

--- a/test/django_gui/test_django_server_api.py
+++ b/test/django_gui/test_django_server_api.py
@@ -4,17 +4,23 @@
 via "./manage.py test". Disabled until we figure out how to force it to use the test database.
 """
 
-import django
 import logging
 import os
 import sys
 import unittest
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_gui.settings')
-django.setup()
+# Django is an optional extra ("pip install '.[web]'"); skip rather than
+# error out at collection time if it isn't installed.
+try:
+    import django
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_gui.settings')
+    django.setup()
 
-from django.test import TestCase  # noqa: E402
-from django_gui.django_server_api import DjangoServerAPI  # noqa: E402
+    from django.test import TestCase  # noqa: E402
+    from django_gui.django_server_api import DjangoServerAPI  # noqa: E402
+except ImportError:
+    raise unittest.SkipTest(
+        "Django not installed; run: pip install '.[web]'")
 
 sample_test_0 = {
     "cruise": {

--- a/utils/install_openrvdas.sh
+++ b/utils/install_openrvdas.sh
@@ -781,6 +781,14 @@ function setup_python_packages {
     # sys.path hacks (requires pyproject.toml, present from v2.x onwards).
     if [ -f pyproject.toml ]; then
         venv/bin/python venv/bin/pip3 install -e .
+
+        # Django/uwsgi are an optional extra so that logger-only installs
+        # (UI_TYPE=none) don't need a C compiler to build uwsgi. Pull them
+        # in whenever a web UI was requested.
+        if [[ "${UI_TYPE:-}" != "none" ]]; then
+            echo "Installing web UI packages (Django, uwsgi)."
+            venv/bin/python venv/bin/pip3 install -e '.[web]'
+        fi
     fi
 }
 

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -8,7 +8,7 @@
 
 # Packages
 pyserial
-uwsgi
+#uwsgi   # see "Django web console" note below
 websockets
 PyYAML
 parse
@@ -28,15 +28,22 @@ pyModbusTCP
 #geopandas
 #shapely
 
-django
-djangorestframework
+# For the Django web console (optional - only needed for UI_TYPE=django).
+# Not installed by default: uwsgi needs a C compiler and OpenSSL headers,
+# which makes a default install fail on minimal or embedded systems. The
+# installer adds these automatically when a web UI is selected.
+#
+# To enable the Django console manually:
+#   pip install '.[web]'
+#django
+#djangorestframework
 
 # Version-restricted packages
 #django==5.0.3
 #djangorestframework==3.15.1
 
 #includes the swagger ui css and javascript
-drf-spectacular[sidecar]
+#drf-spectacular[sidecar]
 
 # For testing
 pytest


### PR DESCRIPTION
> **Stacked on #591.** Base is `geofence_optional_deps`, so this diff shows only the web-extra change. GitHub will retarget it to `dev` automatically once #591 merges. Please merge #591 first.

## Problem

`django`, `djangorestframework`, `drf-spectacular` and `uwsgi` are hard dependencies, even though **nothing in the core logger pipeline imports them** — Django usage is confined to `django_gui/` and its two test modules.

`uwsgi` is the practical blocker: it needs a C compiler and OpenSSL headers to build. A Raspberry Pi running loggers and reporting to a server elsewhere has no use for the Django console, but still had to compile uwsgi to finish an install.

## Why this is safe

The installer already asks which UI to install and already gates the web setup:

| Line | Behavior |
|---|---|
| ~2183 | `read -p "Which web UI would you like to install? (django/react/none)"` |
| 2279 | `setup_python_packages` — runs **after** the UI choice, so the extra can be installed conditionally |
| 2284 | nginx setup gated on `UI_TYPE != "none"` |
| 2322 | `setup_uwsgi` already gated on `UI_TYPE == "django"` |

The code was already written for this. `server/logger_manager.py:720` imports `DjangoServerAPI` inside `if args.database == 'django':`, with a comment reading *"Do our imports conditionally, so they don't actually have to have Django if they're not using it."* `manage.py` already raises a friendly error when Django is missing. This PR makes the packaging match that existing intent.

The extra is installed whenever `UI_TYPE != "none"` — deliberately covering **both** `django` and `react` rather than django-only, so the React path cannot regress.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | New `web` extra. Core dependencies drop **12 → 8** |
| `utils/requirements.txt` | Commented out, with a note on why |
| `utils/install_openrvdas.sh` | `pip install -e '.[web]'` from `setup_python_packages` when `UI_TYPE != none` |
| `test/django_gui/*.py` (2 files) | Wrap module-level `django.setup()` imports in try/except → `unittest.SkipTest` |

Core dependencies are now:

```
PyYAML  influxdb_client  parse  psutil  pyModbusTCP  pyserial  setproctitle  websockets
```

## The test guard matters more here than in #591

Both Django test modules call `django.setup()` and `from django.test import TestCase` at **module scope**. Without a guard that isn't a test failure — it's a **collection error**, which is noisier and harder to diagnose. Raising `unittest.SkipTest` at module level is honored by both pytest and `manage.py test`.

## Tests

- `pytest test/` — **404 passed, 51 skipped** (unchanged from before this PR)
- `pytest test/django_gui/` with Django installed — 17 passed, 1 skipped
- Same with `django`/`rest_framework`/`drf_spectacular` blocked at import — **2 skipped, 0 errors**
- Verified the core pipeline imports with `django`/`uwsgi`/`rest_framework` all blocked: `listen`, readers, writers, transforms, `logger_manager`, `logger_runner` all fine
- `bash -n utils/install_openrvdas.sh` — syntax OK
- `flake8` clean on both changed test files

## Behavior change

A user who runs the installer and picks a web UI is unaffected — the extra is installed for them. A user doing a **manual** `pip install -e .` and expecting the Django console will now need `pip install -e '.[web]'`. That's the intended trade, and it's what makes a compiler-free logger-only install possible.

Not addressed here: `utils/requirements.txt` and `pyproject.toml` remain hand-maintained duplicates. Consolidating them is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)