### PR TITLE
Make configs able to import contrib/ and local/ modules again

### DIFF
--- a/logger/listener/listen.py
+++ b/logger/listener/listen.py
@@ -45,6 +45,8 @@ import pprint
 import re
 import sys
 
+from os.path import dirname, realpath
+
 
 # flake8: noqa E402, F406
 from logger.readers import *
@@ -135,6 +137,40 @@ class ListenerFromLoggerConfig(Listener):
         return kwargs
 
     ############################
+    @staticmethod
+    def _import_module(class_module_name):
+        """Import a module named by a 'module' declaration in a logger config.
+
+        Configs may name modules that live in the OpenRVDAS tree but are
+        deliberately not installed as packages: contrib/ and local/ are both
+        excluded from [tool.setuptools.packages.find] in pyproject.toml. When
+        listen.py is run as a script, or via its 'listen' console entry point,
+        sys.path[0] is the script's own directory rather than the OpenRVDAS
+        root, so those modules can't be found. Add the root and retry once.
+
+        (Loggers started by LoggerRunner don't hit this: it runs them as
+        'python -m logger.listener.listen' with cwd set to the OpenRVDAS root,
+        which puts the root on sys.path already.)
+        """
+        try:
+            return importlib.import_module(class_module_name)
+        except ModuleNotFoundError as e:
+            # Only retry if the requested module's own top-level package is
+            # what's missing. If the module was found but one of *its* imports
+            # failed - e.g. a contrib driver whose hardware library isn't
+            # installed - the repo root won't help, and retrying would only
+            # obscure the real error.
+            if e.name != class_module_name.split('.')[0]:
+                raise
+            openrvdas_root = dirname(dirname(dirname(realpath(__file__))))
+            if openrvdas_root in sys.path:
+                raise
+            logging.debug('Module "%s" not found; adding "%s" to sys.path and '
+                          'retrying.', class_module_name, openrvdas_root)
+            sys.path.append(openrvdas_root)
+            return importlib.import_module(class_module_name)
+
+    ############################
     def _class_kwargs_from_config(self, class_json):
         """Parse a class's kwargs from a JSON string."""
         if not type(class_json) in [list, dict]:
@@ -153,7 +189,7 @@ class ListenerFromLoggerConfig(Listener):
         # Are they telling us where the class definition is? If so import it
         class_module_name = class_json.get('module')
         if class_module_name is not None:
-            module = importlib.import_module(class_module_name)
+            module = self._import_module(class_module_name)
             class_const = getattr(module, class_name, None)
             if not class_const:
                 raise ValueError('No component class "{}" found in module "{}"'.format(

--- a/test/logger/listener/test_listen.py
+++ b/test/logger/listener/test_listen.py
@@ -3,10 +3,14 @@
 (ListenerFromLoggerConfig) and the command-line assembly helpers."""
 
 import copy
+import importlib
 import logging
+import os
+import sys
 import tempfile
 import unittest
 import warnings
+from unittest import mock
 
 from logger.listener.listen import (
     ListenerFromLoggerConfig, build_arg_parser, parse_addr_list, build_listener)
@@ -138,6 +142,68 @@ class TestCLIHelpers(unittest.TestCase):
         with open(self.dest) as f:
             out = [line.rstrip() for line in f.readlines()]
         self.assertEqual(out, ['pre line1', 'pre line2'])
+
+
+################################################################################
+class TestImportModule(unittest.TestCase):
+    """Configs may name modules that live in the OpenRVDAS tree but aren't
+    installed as packages (contrib/, local/). Verify _import_module() finds
+    them even when the OpenRVDAS root isn't on sys.path, which is the case
+    when listen.py is run as a script or via its console entry point.
+    """
+    # 'contrib' is a namespace package with no third-party dependencies of
+    # its own, which makes it a safe target to import in a test.
+    UNINSTALLED_PACKAGE = 'contrib'
+
+    ############################
+    def setUp(self):
+        self.orig_sys_path = list(sys.path)
+        self.orig_modules = dict(sys.modules)
+        self.openrvdas_root = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.realpath(__file__)))))
+        # Simulate script invocation: OpenRVDAS root not on sys.path, and the
+        # package not already imported by some earlier test.
+        sys.path[:] = [p for p in sys.path
+                       if os.path.realpath(p or os.getcwd()) != self.openrvdas_root]
+        sys.modules.pop(self.UNINSTALLED_PACKAGE, None)
+
+    ############################
+    def tearDown(self):
+        sys.path[:] = self.orig_sys_path
+        sys.modules.clear()
+        sys.modules.update(self.orig_modules)
+
+    ############################
+    def test_plain_import_fails_without_root(self):
+        """Guard the premise: without the root on sys.path, a plain import
+        of an uninstalled package really does fail. If this ever starts
+        passing, the test below is no longer proving anything."""
+        with self.assertRaises(ModuleNotFoundError):
+            importlib.import_module(self.UNINSTALLED_PACKAGE)
+
+    ############################
+    def test_import_module_adds_root_and_succeeds(self):
+        module = ListenerFromLoggerConfig._import_module(self.UNINSTALLED_PACKAGE)
+        self.assertIsNotNone(module)
+        self.assertIn(self.openrvdas_root, sys.path)
+
+    ############################
+    def test_genuinely_missing_module_still_raises(self):
+        """A typo'd or absent module must still fail, not be papered over."""
+        with self.assertRaises(ModuleNotFoundError):
+            ListenerFromLoggerConfig._import_module('no_such_module_xyzzy')
+
+    ############################
+    def test_missing_sub_dependency_is_not_masked(self):
+        """If the module itself is found but one of *its* imports fails - e.g.
+        a contrib driver whose hardware library isn't installed - the error
+        must propagate immediately, with no pointless second attempt."""
+        err = ModuleNotFoundError("No module named 'somedep'", name='somedep')
+        with mock.patch('importlib.import_module', side_effect=err) as mock_import:
+            with self.assertRaises(ModuleNotFoundError) as ctx:
+                ListenerFromLoggerConfig._import_module('contrib.some.driver')
+        self.assertEqual(ctx.exception.name, 'somedep')
+        self.assertEqual(mock_import.call_count, 1)  # no retry
 
 
 ################################################################################


### PR DESCRIPTION
## Problem

A logger config can name a class's module explicitly:

```yaml
readers:
  - class: BME688Reader
    module: contrib.raspberrypi.readers.bme688_reader
```

Running that by hand fails:

```
File "logger/listener/listen.py", line 156, in _class_kwargs_from_config
    module = importlib.import_module(class_module_name)
ModuleNotFoundError: No module named 'contrib'
```

When `listen.py` runs as a script — or via its `listen` console entry point — `sys.path[0]` is the script's own directory, not the OpenRVDAS root. `contrib/` and `local/` are deliberately excluded from `[tool.setuptools.packages.find]`, so `pip install -e .` doesn't map them either. The `sys.path` fix-ups that used to cover this were removed in #544/#545 during the pyproject migration.

| Invocation | `sys.path[0]` | `contrib` importable? |
|---|---|---|
| `logger/listener/listen.py …` (as the docs suggest) | `logger/listener/` | ❌ |
| `listen` console script | `venv/bin/` | ❌ |
| `python -m logger.listener.listen` from repo root | repo root | ✅ |
| LoggerRunner → supervisord (production) | repo root (`cwd=OPENRVDAS_ROOT`) | ✅ |

Production is unaffected. The failure is specific to running a logger by hand — exactly when someone is bringing up a new sensor.

## That it ever worked is an accident worth not preserving

`database/settings.py` does `sys.path.append('.')`, and `logger/readers/database_reader.py` imports it inside a `try/except`. So on a machine where that **generated, gitignored** file exists and imports cleanly, *and* the user happens to be sitting in the OpenRVDAS root, `'.'` lands on `sys.path` and `contrib` resolves. On a fresh checkout, an interrupted install, or from any other working directory, it doesn't.

This cost me a confusing debugging session: an initial before/after test showed no difference, because my dev box had the accident active. With `database/settings.py` moved aside, the difference is exact:

```
BEFORE:  ModuleNotFoundError: No module named 'contrib'
AFTER:   ModuleNotFoundError: No module named 'adafruit_bme680'
```

That second error is correct and expected — `contrib` resolved, and the driver's own hardware library genuinely isn't installed.

## Approach

Rather than restoring a blanket `sys.path` fix-up at import time — undoing what #544/#545 deliberately cleaned up across 176 files — add the root **lazily**, at the one place that needs it: the dynamic import of a module named in a config.

The retry is gated on the requested module's own top-level package being what's missing. If the module was found but one of *its* imports failed, the error propagates unchanged rather than being retried and obscured.

`listen.py:156` is the only dynamic-import site that matters; the other (`nmea_transform.py:67`) hardcodes an always-packaged `logger.transforms.*` path.

## Tests

Four new tests in `test/logger/listener/test_listen.py`:

- an uninstalled package resolves through the helper when the root isn't on `sys.path`
- a **premise guard** asserting that a plain import really does fail under those conditions — so the test above can't silently stop testing anything if the environment changes
- a genuinely absent module still raises
- a missing sub-dependency raises immediately with `call_count == 1`, proving no pointless retry

`setUp`/`tearDown` snapshot and restore both `sys.path` and `sys.modules`, so these can't leak into other tests.

- `pytest test/` — **408 passed, 51 skipped** (was 404 passed; +4 new)
- `flake8` clean on both changed files
- End-to-end verified against the reported failure, with the accidental `'.'` append neutralized

## Follow-ups (not addressed here)

1. `database/settings.py`'s `sys.path.append('.')` is a cwd-dependent side effect of an unrelated module and should probably go, but removing it could break setups that unknowingly depend on it.
2. `contrib` drivers have undocumented dependencies — `bme688_reader.py` needs `adafruit_bme680` and `board`, which appear in no requirements file.
3. #545's test plan has an unchecked box reading *"`python3 logger/listener/listen.py --help` works after `pip install -e .`"*. This is what fell through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)