### PR TITLE
Consolidate dependencies on pyproject.toml and add version ceilings

### DIFF
--- a/database/install_mysql.sh
+++ b/database/install_mysql.sh
@@ -407,12 +407,18 @@ function setup_python_packages {
       --trusted-host pypi.org --trusted-host files.pythonhosted.org \
       wheel  # To help with the rest of the installations
 
-    pip install -r utils/requirements.txt
+    # Dependencies are declared in pyproject.toml; installing the project
+    # itself pulls them in.
+    pip install \
+      --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+      -e .
 
     # If we're installing database, then also install relevant
-    # Python clients.
+    # Python clients, declared as the "mysql" extra.
     if [ $INSTALL_MYSQL == 'yes' ]; then
-      pip install -r utils/requirements_mysql.txt
+      pip install \
+        --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+        -e '.[mysql]'
     fi
 }
 ###########################################################################

--- a/docs/html/README.md
+++ b/docs/html/README.md
@@ -15,8 +15,9 @@ Run the generation script from the repo root:
 ```
 
 Requirements: `pdoc >= 14.0.0` and all OpenRVDAS dependencies installed.
-If using the project venv, pdoc is included in `utils/requirements.txt` and the
-script will activate the venv automatically.
+If using the project venv, pdoc comes from the `dev` extra
+(`pip install -e '.[dev]'`) and the script will activate the venv
+automatically.
 
 ## Live preview during development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ license = { text = "MIT" }
 authors = [
   { name = "OpenRVDAS Contributors" }
 ]
+# Upper bounds are applied to packages that have broken OpenRVDAS (or are
+# known to break APIs) across major versions. See the "Version ceilings" note
+# at the bottom of this file before adding or bumping one.
 dependencies = [
   "PyYAML",
   "influxdb_client",
@@ -20,7 +23,7 @@ dependencies = [
   "pyModbusTCP",
   "pyserial",
   "setproctitle",
-  "websockets"
+  "websockets<18"
 ]
 
 [project.optional-dependencies]
@@ -28,14 +31,17 @@ dependencies = [
 # it. Not needed to run loggers, or for the React UI, which has its own
 # dependencies under web_backend/.
 web = [
-  "django",
-  "djangorestframework",
+  # django<6.1: 6.1 raised the minimum SQLite to 3.37, but RHEL 9, Rocky 9,
+  # Alma 9 and CentOS Stream 9 all ship SQLite 3.34.1, so every install on
+  # those platforms failed at the first ORM call. See issue #590.
+  "django>=4.2,<6.1",
+  "djangorestframework<4",
   "drf-spectacular[sidecar]",
   "uwsgi"
 ]
 geofence = [
-  "geopandas",
-  "shapely"
+  "geopandas<2",
+  "shapely<3"
 ]
 google = [
   "google-api-python-client",
@@ -53,9 +59,27 @@ mqtt = [
   "paho-mqtt"
 ]
 dev = [
-  "pytest",
+  "pytest<10",
   "pdoc>=14.0.0"
 ]
+
+# ---------------------------------------------------------------------------
+# Version ceilings
+#
+# Dependencies here are otherwise deliberately unconstrained, so that patch and
+# minor releases flow through without a repo change. Upper bounds are added
+# only where a major version has broken OpenRVDAS, or where the package has a
+# track record of breaking its API across majors:
+#
+#   django                6.1 raised the minimum SQLite past what RHEL 9 ships
+#   djangorestframework   moves in lockstep with django
+#   websockets            has changed its client/server API across majors
+#   geopandas, shapely    move together and have broken APIs before
+#   pytest                collection/fixture behavior has changed across majors
+#
+# When a new major is validated against OpenRVDAS, bump the ceiling here - this
+# is the only place dependencies are declared. See issue #590.
+# ---------------------------------------------------------------------------
 
 [project.urls]
 Homepage = "https://openrvdas.org/"

--- a/utils/install_openrvdas.sh
+++ b/utils/install_openrvdas.sh
@@ -775,20 +775,27 @@ function setup_python_packages {
         export PKG_CONFIG_PATH="${OPENSSL_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
     fi
 
-    venv/bin/python venv/bin/pip3 install -r utils/requirements.txt
-
-    # Register the package so that direct script invocation works without
-    # sys.path hacks (requires pyproject.toml, present from v2.x onwards).
+    # Dependencies are declared in pyproject.toml; installing the project
+    # itself pulls them in. This also registers the package so that direct
+    # script invocation works without sys.path hacks.
     if [ -f pyproject.toml ]; then
-        venv/bin/python venv/bin/pip3 install -e .
+        venv/bin/python venv/bin/pip3 install \
+          --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+          -e .
 
         # Django/uwsgi are an optional extra so that logger-only installs
         # (UI_TYPE=none) don't need a C compiler to build uwsgi. Pull them
         # in whenever a web UI was requested.
         if [[ "${UI_TYPE:-}" != "none" ]]; then
             echo "Installing web UI packages (Django, uwsgi)."
-            venv/bin/python venv/bin/pip3 install -e '.[web]'
+            venv/bin/python venv/bin/pip3 install \
+              --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+              -e '.[web]'
         fi
+    else
+        # Pre-v2.x checkout with no pyproject.toml: fall back to the
+        # requirements file, which in those versions still listed packages.
+        venv/bin/python venv/bin/pip3 install -r utils/requirements.txt
     fi
 }
 

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,52 +1,42 @@
-# Python/pip requirements for OpenRVDAS. Invoked on installation by the
-# script utils/install_openrvdas.sh. See also requirements_mysql.txt for
-# files required to enable MySQL functionality with OpenRVDAS
+# ---------------------------------------------------------------------------
+# This file no longer declares OpenRVDAS's dependencies.
+#
+# All dependencies - required and optional - are declared in pyproject.toml,
+# which is now the single source of truth. Previously they were listed both
+# here and there, with nothing keeping the two in sync, and the installer ran
+# both: a package added in only one place either got installed twice or not at
+# all, depending on which file you edited. See issue #594.
+#
+# This file is kept so that existing scripts and documentation that run
+#
+#     pip install -r utils/requirements.txt
+#
+# keep working. All it does is install the project itself, which pulls in the
+# dependencies pyproject.toml declares.
+#
+# To add or change a dependency, edit pyproject.toml - NOT this file. Adding a
+# package here would install it without recording it as a project dependency,
+# which is the drift this change was made to eliminate.
+#
+# To install optional features, use the extras:
+#
+#     pip install -e '.[web]'        # Django web console (django, uwsgi)
+#     pip install -e '.[geofence]'   # GeofenceTransform (geopandas, shapely)
+#     pip install -e '.[mysql]'      # MySQL client libraries
+#     pip install -e '.[google]'     # Google Sheets writer
+#     pip install -e '.[mqtt]'       # MQTT reader/writer
+#     pip install -e '.[redis]'      # Redis reader/writer
+#     pip install -e '.[dev]'        # pytest, pdoc
+#
+# NOTE: pip resolves the "-e ." below relative to your current working
+# directory, not to the location of this file. Run it from the OpenRVDAS root:
+#
+#     cd /opt/openrvdas && pip install -r utils/requirements.txt
+# ---------------------------------------------------------------------------
 
 # Flags
 --trusted-host pypi.org
 --trusted-host files.pythonhosted.org
 
-# Packages
-pyserial
-#uwsgi   # see "Django web console" note below
-websockets
-PyYAML
-parse
-psutil
-setproctitle
-influxdb_client
-pyModbusTCP
-
-# For Geofencing (optional - used only by GeofenceTransform).
-#
-# Not installed by default: geopandas pulls in pyogrio, which has no prebuilt
-# wheel for ARMv6/ARMv7 and requires libgdal-dev to compile from source. That
-# makes a default install fail on Raspberry Pi and similar hardware.
-#
-# To enable geofencing:
-#   pip install '.[geofence]'
-#geopandas
-#shapely
-
-# For the Django web console (optional - only needed for UI_TYPE=django).
-# Not installed by default: uwsgi needs a C compiler and OpenSSL headers,
-# which makes a default install fail on minimal or embedded systems. The
-# installer adds these automatically when a web UI is selected.
-#
-# To enable the Django console manually:
-#   pip install '.[web]'
-#django
-#djangorestframework
-
-# Version-restricted packages
-#django==5.0.3
-#djangorestframework==3.15.1
-
-#includes the swagger ui css and javascript
-#drf-spectacular[sidecar]
-
-# For testing
-pytest
-
-# For generating API documentation (see docs/generate_html_docs.sh)
-pdoc>=14.0.0
+# Install OpenRVDAS and the dependencies declared in pyproject.toml.
+-e .

--- a/utils/requirements_mysql.txt
+++ b/utils/requirements_mysql.txt
@@ -1,10 +1,27 @@
-# Python/pip requirements for MySQL functionality in OpenRVDAS. Invoked on
-# installation by the script utils/install_openrvdas.sh. See also requirements.txt.
+# ---------------------------------------------------------------------------
+# This file no longer declares OpenRVDAS's MySQL dependencies.
+#
+# They are declared in pyproject.toml as the "mysql" extra, which is now the
+# single source of truth. See utils/requirements.txt and issue #594.
+#
+# This file is kept so that existing scripts and documentation that run
+#
+#     pip install -r utils/requirements_mysql.txt
+#
+# keep working. It installs the project with its "mysql" extra.
+#
+# To add or change a MySQL dependency, edit the "mysql" extra in
+# pyproject.toml - NOT this file.
+#
+# NOTE: pip resolves the "-e" line below relative to your current working
+# directory, not to the location of this file. Run it from the OpenRVDAS root:
+#
+#     cd /opt/openrvdas && pip install -r utils/requirements_mysql.txt
+# ---------------------------------------------------------------------------
 
 # Flags
 --trusted-host pypi.org
 --trusted-host files.pythonhosted.org
 
-# Packages
-mysqlclient
-mysql-connector
+# Install OpenRVDAS plus the MySQL client libraries.
+-e .[mysql]


### PR DESCRIPTION
Closes #594. Closes #590.

Both are done together deliberately — see "Why one PR" below.

## Part 1: Consolidation (#594)

`utils/requirements.txt` and `utils/requirements_mysql.txt` duplicated what `pyproject.toml` already declared, nothing kept them in sync, and the installer ran **both**. A dependency change had to be made in two places or it silently didn't take effect — which is why #591 and #592 each needed the same edit applied twice.

`pyproject.toml` is now the single source of truth.

**Both requirements files become stubs**, per the decision to keep the paths working for vessel deployment scripts outside this repo:

```
# Flags
--trusted-host pypi.org
--trusted-host files.pythonhosted.org

# Install OpenRVDAS and the dependencies declared in pyproject.toml.
-e .
```

Each carries a comment block explaining that dependencies now live in `pyproject.toml`, that **this file should not be edited to add packages** (doing so would install something without recording it as a project dependency — the exact drift being eliminated), the full list of available extras, and one non-obvious caveat:

> pip resolves the `-e .` relative to your **current working directory**, not to the location of this file.

I verified that behavior rather than assuming it — a requirements file in a subdirectory containing `-e .` resolves against the cwd, so the stub only works when run from the OpenRVDAS root. Both existing callers do run from there.

**Installers now use pyproject directly.** The `--trusted-host` flags that lived in the requirements files move onto the pip command lines, matching what both scripts already do for `pip` and `wheel`.

`install_openrvdas.sh` keeps a fallback to the requirements file when `pyproject.toml` is absent, preserving pre-v2.x behavior.

**`database/install_mysql.sh` is updated too** (lines 410/415). It was the second, easy-to-miss caller — leaving it would have silently stopped installing MySQL dependencies.

## Part 2: Version ceilings (#590, approach 1)

#590's own conclusion was *"Option 1 alone would have prevented this outage,"* so this implements targeted upper bounds rather than blanket pinning. Dependencies stay otherwise unconstrained so patch and minor releases flow without a repo change.

| Constraint | Why |
|---|---|
| `django>=4.2,<6.1` | 6.1 raised minimum SQLite to 3.37; RHEL 9, Rocky 9, Alma 9 and CentOS Stream 9 ship 3.34.1, so every install failed at the first ORM call |
| `djangorestframework<4` | moves in lockstep with django |
| `websockets<18` | has changed its client/server API across majors |
| `geopandas<2`, `shapely<3` | move together, have broken APIs before |
| `pytest<10` | collection/fixture behavior changes across majors |

7 of 23 declarations are now constrained; the other 16 are deliberately left open. A comment block in `pyproject.toml` records the rationale and the bump procedure.

**Verified the fix works:**

```
$ pip install --dry-run -e '.[web]'
Collecting django<6.1,>=4.2 (from openrvdas==0.1.0)
  Downloading django-6.0.8-py3-none-any.whl
```

6.0.8 rather than 6.1 — the version that still supports RHEL 9's SQLite.

## Why one PR

With dependencies declared in two unsynchronized files, constraints added to one would drift from the other, recreating the very problem #594 is about.

This is not hypothetical: **#590's package inventory was already stale.** It lists `uwsgi`, `geopandas`, `shapely`, `django`, `djangorestframework` and `drf-spectacular[sidecar]` as living in `requirements.txt`, but #591/#592 moved them into `pyproject.toml` extras. Adding a Django ceiling to `requirements.txt` today would not have constrained anything.

## Tests

- `pytest test/` — **408 passed, 51 skipped** (unchanged)
- `bash -n` clean on both installer scripts
- Both stubs verified to resolve via `pip install --dry-run -r ...` from the repo root
- `.[web]` verified to resolve django below 6.1

## Note for the release

This is intended to land before the next dev→master push. Without it, that release would carry the #590 exposure to master: `django` is unpinned there, so a fresh RHEL 9 install would resolve 6.1 and fail on `manage.py makemigrations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)