### PR TITLE
Fix headless (UI_TYPE=none) installs broken by #592

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,20 +23,32 @@ dependencies = [
   "pyModbusTCP",
   "pyserial",
   "setproctitle",
-  "websockets<18"
+  "websockets<18",
+
+  # Django is required regardless of which web UI (if any) is installed:
+  # LoggerManager uses the Django ORM as a backing store by default, and
+  # install_openrvdas.sh runs setup_django unconditionally. These are all
+  # pure Python, so they don't stand in the way of a compiler-free install
+  # - only uwsgi does, and that lives in the "web" extra below.
+  #
+  # django<6.1: 6.1 raised the minimum SQLite to 3.37, but RHEL 9, Rocky 9,
+  # Alma 9 and CentOS Stream 9 all ship SQLite 3.34.1, so every install on
+  # those platforms failed at the first ORM call. See issue #590.
+  "django>=4.2,<6.1",
+  "djangorestframework<4",
+  "drf-spectacular[sidecar]"
 ]
 
 [project.optional-dependencies]
 # Django web console (UI_TYPE=django) and the nginx/uwsgi stack that serves
 # it. Not needed to run loggers, or for the React UI, which has its own
 # dependencies under web_backend/.
+# The application server that fronts the Django console. This is the only
+# web-stack dependency that needs a C compiler and OpenSSL headers, which is
+# why it's split out: a logger-only or React install never builds it.
+# install_openrvdas.sh installs this extra when UI_TYPE=django, matching the
+# condition it already uses to run setup_uwsgi.
 web = [
-  # django<6.1: 6.1 raised the minimum SQLite to 3.37, but RHEL 9, Rocky 9,
-  # Alma 9 and CentOS Stream 9 all ship SQLite 3.34.1, so every install on
-  # those platforms failed at the first ORM call. See issue #590.
-  "django>=4.2,<6.1",
-  "djangorestframework<4",
-  "drf-spectacular[sidecar]",
   "uwsgi"
 ]
 geofence = [

--- a/utils/install_openrvdas.sh
+++ b/utils/install_openrvdas.sh
@@ -783,11 +783,13 @@ function setup_python_packages {
           --trusted-host pypi.org --trusted-host files.pythonhosted.org \
           -e .
 
-        # Django/uwsgi are an optional extra so that logger-only installs
-        # (UI_TYPE=none) don't need a C compiler to build uwsgi. Pull them
-        # in whenever a web UI was requested.
-        if [[ "${UI_TYPE:-}" != "none" ]]; then
-            echo "Installing web UI packages (Django, uwsgi)."
+        # uwsgi is an optional extra: it's the only web-stack dependency that
+        # needs a C compiler, so logger-only (UI_TYPE=none) and React installs
+        # don't build it. Django itself is a core dependency, because
+        # LoggerManager uses the Django ORM regardless of UI choice.
+        # This condition matches the one guarding setup_uwsgi below.
+        if [[ "${UI_TYPE:-}" == "django" ]]; then
+            echo "Installing uwsgi for the Django web console."
             venv/bin/python venv/bin/pip3 install \
               --trusted-host pypi.org --trusted-host files.pythonhosted.org \
               -e '.[web]'

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -20,7 +20,7 @@
 #
 # To install optional features, use the extras:
 #
-#     pip install -e '.[web]'        # Django web console (django, uwsgi)
+#     pip install -e '.[web]'        # uwsgi, to serve the Django console
 #     pip install -e '.[geofence]'   # GeofenceTransform (geopandas, shapely)
 #     pip install -e '.[mysql]'      # MySQL client libraries
 #     pip install -e '.[google]'     # Google Sheets writer


### PR DESCRIPTION
> ⚠️ **Blocks the v2.6.1 release (#596).** This is a regression introduced by #592 and currently sitting on `dev`. #596 should not merge until this is in.

## The bug

#592 moved `django`, `djangorestframework`, `drf-spectacular` and `uwsgi` into a `web` extra installed only when `UI_TYPE != none`. That was wrong: **Django is not a web-UI dependency in this codebase — it's LoggerManager's default backing store.**

With `UI_TYPE=none`, `install_openrvdas.sh` still:

- runs **`setup_django` unconditionally** (line ~2354), whose own comment reads *"always needed — logger_manager uses Django ORM regardless of which web UI is selected"*, and which invokes `manage.py makemigrations` / `migrate`; and
- writes **`LOGGER_MANAGER_DATABASE=django`** into the supervisord config for every UI type except react (line ~1549).

So a headless install fails at `setup_django` with `ModuleNotFoundError: No module named 'django'`, and would fail again at runtime even if it got past that.

This worked before #592, when `django` was a core dependency. Ironically it breaks precisely the logger-only install that #592 was meant to enable — the Raspberry-Pi case that motivated the whole effort.

## The fix: the split was in the wrong place

Of the four packages, **only `uwsgi` needs a C compiler** and OpenSSL headers. `django`, `djangorestframework` and `drf-spectacular` are pure Python and were never the obstacle.

| | Before (broken) | After |
|---|---|---|
| `django`, `djangorestframework`, `drf-spectacular` | `web` extra | **core** (ceilings from #595 preserved) |
| `uwsgi` | `web` extra | `web` extra (unchanged) |
| Installer gate | `UI_TYPE != none` | `UI_TYPE == django` |

The new gate matches the condition that already guards `setup_uwsgi` (line 2337) instead of the broader `!= none`. React installs don't need uwsgi either — they use uvicorn via `web_backend` — so this also stops React installs from building a package they never use.

This preserves what #592 was actually for (a default install requiring no compiler, so ARM and embedded systems can install) while restoring the ORM the installer depends on.

## Verification

```
$ pip install --dry-run -e .
Collecting django<6.1,>=4.2 (from openrvdas==0.1.0)
  Using cached django-6.0.8-py3-none-any.whl
Would install Django-6.0.8 openrvdas-0.1.0

$ pip install --dry-run -e . | grep -ci uwsgi
0
```

Django present at the correct version (still respecting #590's ceiling), no uwsgi, no compiler needed.

- `pytest test/` — **408 passed, 51 skipped** (unchanged)
- `bash -n utils/install_openrvdas.sh` — clean
- Both `UI_TYPE == django` gates verified consistent (lines 791 and 2337)

## Follow-up worth considering separately

A genuinely headless mode would go further: with `UI_TYPE=none`, use the `sqlite` LoggerManager backend and skip `setup_django` entirely, so Django isn't needed at all. That's a behavior change to how logger state is stored, so it belongs in its own PR — this one only restores what #592 broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)